### PR TITLE
feat(mesh): configurable corner radius

### DIFF
--- a/src/cartographer/config/parser.py
+++ b/src/cartographer/config/parser.py
@@ -72,6 +72,7 @@ def parse_scan_config(wrapper: ParseConfigWrapper, models: dict[str, ScanModelCo
         mesh_direction=get_choice(wrapper, "mesh_direction", _directions, default="x"),
         mesh_height=wrapper.get_float("mesh_height", default=4, minimum=1),
         mesh_path=get_choice(wrapper, "mesh_path", _paths, default="snake"),
+        mesh_corner_radius=wrapper.get_float("mesh_corner_radius", default=2, minimum=0),
     )
 
 

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -19,6 +19,7 @@ class ScanConfig:
     models: dict[str, ScanModelConfiguration]
     mesh_runs: int
     mesh_height: float
+    mesh_corner_radius: float
     mesh_direction: Literal["x", "y"]
     mesh_path: Literal["snake", "alternating_snake", "spiral"]
 

--- a/src/cartographer/macros/bed_mesh/scan_mesh.py
+++ b/src/cartographer/macros/bed_mesh/scan_mesh.py
@@ -37,6 +37,7 @@ class BedMeshCalibrateConfiguration:
     runs: int
     direction: Literal["x", "y"]
     height: float
+    corner_radius: float
     path: Literal["snake", "alternating_snake", "spiral"]
 
     @staticmethod
@@ -50,6 +51,7 @@ class BedMeshCalibrateConfiguration:
             runs=config.scan.mesh_runs,
             direction=config.scan.mesh_direction,
             height=config.scan.mesh_height,
+            corner_radius=config.scan.mesh_corner_radius,
             path=config.scan.mesh_path,
         )
 
@@ -112,9 +114,10 @@ class BedMeshCalibrateMacro(Macro, SupportsFallbackMacro):
         probe_count = get_int_tuple(params, "PROBE_COUNT", default=self.config.probe_count)
         runs = params.get_int("RUNS", default=self.config.runs, minval=1)
         height = params.get_float("HEIGHT", default=self.config.height, minval=0.5, maxval=5)
+        corner_radius = params.get_float("CORNER_RADIUS", default=self.config.corner_radius, minval=0)
         direction: Literal["x", "y"] = get_choice(params, "DIRECTION", _directions, default=self.config.direction)
         path_strategy_type = get_choice(params, "PATH", default=self.config.path, choices=PATH_STRATEGY_MAP.keys())
-        path_strategy = PATH_STRATEGY_MAP[path_strategy_type](direction)
+        path_strategy = PATH_STRATEGY_MAP[path_strategy_type](direction, corner_radius)
 
         mesh_points = self._generate_mesh_points(mesh_min, mesh_max, probe_count)
         path = list(path_strategy.generate_path(mesh_points))

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -28,6 +28,7 @@ default_scan_config = ScanConfig(
     mesh_runs=1,
     mesh_direction="x",
     mesh_height=4.0,
+    mesh_corner_radius=2.0,
     mesh_path="snake",
 )
 default_touch_config = TouchConfig(


### PR DESCRIPTION
We can now configure the corner radius via
```ini
[cartographer scan]
mesh_corner_radius: 2
```