### PR TITLE
fix(touch): apply z_offset on all probing moves

### DIFF
--- a/src/cartographer/macros/touch.py
+++ b/src/cartographer/macros/touch.py
@@ -140,7 +140,7 @@ class TouchHomeMacro(Macro):
                 self._toolhead.clear_z_homing_state()
 
         pos = self._toolhead.get_position()
-        self._toolhead.set_z_position(pos.z - (trigger_pos - self._probe.offset.z))
+        self._toolhead.set_z_position(pos.z - trigger_pos)
         logger.info(
             "Touch home at (%.3f,%.3f) adjusted z by %.3f, offset %.3f",
             pos.x,

--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -175,7 +175,7 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
         trigger_pos = self._toolhead.z_homing_move(self, bottom=-2.0, speed=model.speed)
         pos = self._toolhead.get_position()
         self._toolhead.move(z=max(pos.z + RETRACT_DISTANCE, RETRACT_DISTANCE), speed=5)
-        return trigger_pos
+        return trigger_pos + model.z_offset
 
     @override
     def home_start(self, print_time: float) -> object:

--- a/tests/macros/test_touch.py
+++ b/tests/macros/test_touch.py
@@ -146,21 +146,3 @@ def test_touch_home_macro(
     macro.run(params)
 
     assert set_z_position_spy.mock_calls == [mocker.call(1.9)]
-
-
-def test_touch_home_macro_with_z_offset(
-    mocker: MockerFixture,
-    probe: Probe,
-    offset: Position,
-    toolhead: Toolhead,
-    params: MacroParams,
-):
-    macro = TouchHomeMacro(probe, toolhead, (10, 10))
-    probe.perform_probe = mocker.Mock(return_value=0.0)
-    offset.z = -0.1
-    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 2))
-    set_z_position_spy = mocker.spy(toolhead, "set_z_position")
-
-    macro.run(params)
-
-    assert set_z_position_spy.mock_calls == [mocker.call(1.9)]


### PR DESCRIPTION
We only applied the z-offset when we were homing. This caused some weird discrepancies, especially with a larger z-offset.
We should always apply it, as it is linked to the method, not just homing.