### PR TITLE
fix(touch): set a small default z_offset

### DIFF
--- a/src/cartographer/config/parser.py
+++ b/src/cartographer/config/parser.py
@@ -110,5 +110,5 @@ def parse_touch_model_config(wrapper: ParseConfigWrapper) -> TouchModelConfigura
         name=wrapper.get_name(),
         threshold=wrapper.get_int("threshold", default=100),
         speed=wrapper.get_float("speed", default=50, minimum=1),
-        z_offset=wrapper.get_float("z_offset", default=0),
+        z_offset=wrapper.get_float("z_offset", default=0, maximum=0),
     )

--- a/src/cartographer/macros/touch_calibrate.py
+++ b/src/cartographer/macros/touch_calibrate.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 MIN_ALLOWED_STEP = 75
 MAX_ALLOWED_STEP = 500
 DEFAULT_TOUCH_MODEL_NAME = "default"
+DEFAULT_Z_OFFSET = -0.05
 
 
 class CalibrationStrategy(ABC):
@@ -212,7 +213,7 @@ class TouchCalibrateMacro(Macro):
         logger.info(
             "Successfully calibrated with %s strategy (threshold %d, speed %.1f)", strategy_type, threshold, speed
         )
-        model = TouchModelConfiguration(name, threshold, speed, 0)
+        model = TouchModelConfiguration(name, threshold, speed, DEFAULT_Z_OFFSET)
         self._config.save_touch_model(model)
         logger.info(
             """


### PR DESCRIPTION
It makes sense to set a small z_offset to ensure we lift the nozzle a bit above the plate.
Of course the user should always calibrate, but this could save a plate..