### PR TITLE
feat(macros): allow optional user-defined prefix

### DIFF
--- a/src/cartographer/adapters/klipper/configuration.py
+++ b/src/cartographer/adapters/klipper/configuration.py
@@ -39,6 +39,10 @@ class KlipperConfigWrapper(ParseConfigWrapper):
         return self._config.get(option, default=default)
 
     @override
+    def get_optional_str(self, option: str) -> str | None:
+        return self._config.get(option, default=None)
+
+    @override
     def get_float(
         self, option: str, default: float, minimum: float | None = None, maximum: float | None = None
     ) -> float:

--- a/src/cartographer/config/parser.py
+++ b/src/cartographer/config/parser.py
@@ -30,6 +30,7 @@ def get_choice(params: ParseConfigWrapper, option: str, choices: Iterable[K], de
 class ParseConfigWrapper(Protocol):
     def get_name(self) -> str: ...
     def get_str(self, option: str, default: str) -> str: ...
+    def get_optional_str(self, option: str) -> str | None: ...
     def get_float(
         self, option: str, default: float, minimum: float | None = None, maximum: float | None = None
     ) -> float: ...
@@ -56,7 +57,7 @@ def parse_general_config(wrapper: ParseConfigWrapper) -> GeneralConfig:
         y_offset=wrapper.get_required_float("y_offset"),
         z_backlash=wrapper.get_float("z_backlash", default=0.05, minimum=0),
         travel_speed=wrapper.get_float("travel_speed", default=50, minimum=1),
-        macro_prefix=wrapper.get_str("macro_prefix", default="CARTOGRAPHER"),
+        macro_prefix=wrapper.get_optional_str("macro_prefix"),
         verbose=wrapper.get_bool("verbose", default=False),
     )
 

--- a/src/cartographer/core.py
+++ b/src/cartographer/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from itertools import chain
 from typing import TYPE_CHECKING, final
 
 from cartographer.macros.axis_twist_compensation import AxisTwistCompensationMacro
@@ -54,43 +55,57 @@ class PrinterCartographer:
 
         probe = Probe(self.scan_mode, self.touch_mode)
 
-        prefix = config.general.macro_prefix.rstrip("_").upper() + "_" if config.general.macro_prefix else ""
+        def reg(name: str, macro: Macro, use_prefix: bool = True) -> list[MacroRegistration]:
+            if not use_prefix:
+                return [MacroRegistration(name, macro)]
 
-        def reg(name: str, macro: Macro, use_prefix: bool = True) -> MacroRegistration:
-            full_name = f"{prefix}{name}" if use_prefix else name
-            return MacroRegistration(full_name, macro)
+            registrations = [MacroRegistration(f"CARTOGRAPHER_{name}", macro)]
+
+            prefix = config.general.macro_prefix
+            if prefix is not None:
+                formatted_prefix = prefix.rstrip("_").upper() + "_" if prefix else ""
+                registrations.append(MacroRegistration(f"{formatted_prefix}{name}", macro))
+
+            return registrations
 
         self.probe_macro = ProbeMacro(probe)
         self.query_probe_macro = QueryProbeMacro(probe)
-        self.macros = [
-            reg("PROBE", self.probe_macro, use_prefix=False),
-            reg("PROBE_ACCURACY", ProbeAccuracyMacro(probe, toolhead), use_prefix=False),
-            reg("QUERY_PROBE", self.query_probe_macro, use_prefix=False),
-            reg("Z_OFFSET_APPLY_PROBE", ZOffsetApplyProbeMacro(probe, toolhead, config), use_prefix=False),
-            reg(
-                "BED_MESH_CALIBRATE",
-                BedMeshCalibrateMacro(
-                    probe,
-                    toolhead,
-                    adapters.bed_mesh,
-                    adapters.task_executor,
-                    BedMeshCalibrateConfiguration.from_config(config),
-                ),
-                use_prefix=False,
-            ),
-            reg("SCAN_CALIBRATE", ScanCalibrateMacro(probe, toolhead, config)),
-            reg("ESTIMATE_BACKLASH", EstimateBacklashMacro(toolhead, self.scan_mode, config)),
-            reg("TOUCH_CALIBRATE", TouchCalibrateMacro(probe, self.mcu, toolhead, config)),
-            reg("TOUCH", TouchMacro(self.touch_mode)),
-            reg("TOUCH_ACCURACY", TouchAccuracyMacro(self.touch_mode, toolhead)),
-            reg("TOUCH_HOME", TouchHomeMacro(self.touch_mode, toolhead, config.bed_mesh.zero_reference_position)),
-        ]
+        self.macros = list(
+            chain.from_iterable(
+                [
+                    reg("PROBE", self.probe_macro, use_prefix=False),
+                    reg("PROBE_ACCURACY", ProbeAccuracyMacro(probe, toolhead), use_prefix=False),
+                    reg("QUERY_PROBE", self.query_probe_macro, use_prefix=False),
+                    reg("Z_OFFSET_APPLY_PROBE", ZOffsetApplyProbeMacro(probe, toolhead, config), use_prefix=False),
+                    reg(
+                        "BED_MESH_CALIBRATE",
+                        BedMeshCalibrateMacro(
+                            probe,
+                            toolhead,
+                            adapters.bed_mesh,
+                            adapters.task_executor,
+                            BedMeshCalibrateConfiguration.from_config(config),
+                        ),
+                        use_prefix=False,
+                    ),
+                    reg("SCAN_CALIBRATE", ScanCalibrateMacro(probe, toolhead, config)),
+                    reg("ESTIMATE_BACKLASH", EstimateBacklashMacro(toolhead, self.scan_mode, config)),
+                    reg("TOUCH_CALIBRATE", TouchCalibrateMacro(probe, self.mcu, toolhead, config)),
+                    reg("TOUCH", TouchMacro(self.touch_mode)),
+                    reg("TOUCH_ACCURACY", TouchAccuracyMacro(self.touch_mode, toolhead)),
+                    reg(
+                        "TOUCH_HOME", TouchHomeMacro(self.touch_mode, toolhead, config.bed_mesh.zero_reference_position)
+                    ),
+                ]
+            )
+        )
 
         if adapters.axis_twist_compensation:
-            self.macros.append(
+            self.macros.extend(
                 reg(
-                    "AUTO_AXIS_TWIST_COMPENSATION",
+                    "CARTOGRAPHER_AXIS_TWIST_COMPENSATION",
                     AxisTwistCompensationMacro(probe, toolhead, adapters.axis_twist_compensation, config),
+                    use_prefix=False,
                 )
             )
 

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -11,7 +11,7 @@ class GeneralConfig:
     z_backlash: float
     travel_speed: float
     verbose: bool
-    macro_prefix: str
+    macro_prefix: str | None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
User can define
```
[cartographer]
macro_prefix: carto
```
To also register `CARTO_TOUCH`, etc.