### PR TITLE
fix(touch): correct homing z-offset direction

### DIFF
--- a/src/cartographer/macros/touch.py
+++ b/src/cartographer/macros/touch.py
@@ -137,11 +137,10 @@ class TouchHomeMacro(Macro):
                 self._toolhead.clear_z_homing_state()
 
         pos = self._toolhead.get_position()
-        self._toolhead.set_z_position(pos.z - trigger_pos)
+        self._toolhead.set_z_position(pos.z + trigger_pos)
         logger.info(
-            "Touch home at (%.3f,%.3f) adjusted z by %.3f, offset %.3f",
+            "Touch home at (%.3f,%.3f) adjusted z by %.3f",
             pos.x,
             pos.y,
-            -trigger_pos,
-            -self._probe.offset.z,
+            trigger_pos,
         )

--- a/tests/macros/test_touch.py
+++ b/tests/macros/test_touch.py
@@ -138,11 +138,18 @@ def test_touch_home_macro(
     toolhead: Toolhead,
     params: MacroParams,
 ):
+    # We are at 2, and touch the bed at -0.1.
+    height = 2
+    trigger = -0.1
+    # That means that the bed was further away than we thought,
+    # so we need to move the z axis "down".
+    expected = height + trigger
+
     macro = TouchHomeMacro(probe, toolhead, (10, 10))
-    probe.perform_probe = mocker.Mock(return_value=0.1)
-    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 2))
+    probe.perform_probe = mocker.Mock(return_value=trigger)
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, height))
     set_z_position_spy = mocker.spy(toolhead, "set_z_position")
 
     macro.run(params)
 
-    assert set_z_position_spy.mock_calls == [mocker.call(1.9)]
+    assert set_z_position_spy.mock_calls == [mocker.call(expected)]


### PR DESCRIPTION
Discord user dmrn210 discovered this issue, where I inverted the z offset by mistake during a refactor.
This happened in #207 