### PR TITLE
fix(touch): correctly save offset for touch

### DIFF
--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -95,8 +95,7 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
     @property
     @override
     def offset(self) -> Position:
-        z_offset = self.get_model().z_offset if self.has_model() else 0.0
-        return Position(0.0, 0.0, z_offset)
+        return Position(0.0, 0.0, 0.0)
 
     @property
     @override

--- a/tests/bdd/step_definitions/conftest.py
+++ b/tests/bdd/step_definitions/conftest.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
     from pytest import LogCaptureFixture
     from pytest_bdd.parser import Feature, Scenario
 
-    from cartographer.probe.probe import Probe
+    from cartographer.probe.scan_mode import ScanMode
+    from cartographer.probe.touch_mode import TouchMode
     from cartographer.stream import Session
     from tests.mocks.params import MockParams
 
@@ -65,27 +66,27 @@ def given_probe() -> None:
 
 
 @given("the probe has scan calibrated")
-def given_scan_calibrated(probe: Probe, config: Configuration, session: Session[Sample]):
+def given_scan_calibrated(scan: ScanMode, config: Configuration, session: Session[Sample]):
     config.save_scan_model(
         ScanModelConfiguration(name="default", coefficients=[0.3] * 9, domain=(0.1, 5.5), z_offset=0.0)
     )
-    probe.scan.load_model("default")
+    scan.load_model("default")
     session.get_items = lambda: [sample(frequency=2) for _ in range(11)]
 
 
 @given(parsers.parse("the probe has scan z-offset {offset:g}"))
-def given_scan_offset(probe: Probe, config: Configuration, offset: float):
+def given_scan_offset(scan: ScanMode, config: Configuration, offset: float):
     config.save_scan_model(replace(config.scan.models["default"], z_offset=offset))
-    probe.scan.load_model("default")
+    scan.load_model("default")
 
 
 @given("the probe has touch calibrated")
-def given_touch_calibrated(probe: Probe, config: Configuration):
+def given_touch_calibrated(touch: TouchMode, config: Configuration):
     config.touch.models["default"] = TouchModelConfiguration(name="default", threshold=1000, speed=3, z_offset=0.0)
-    probe.touch.load_model("default")
+    touch.load_model("default")
 
 
 @given(parsers.parse("the probe has touch z-offset {offset:g}"))
-def given_touch_offset(probe: Probe, config: Configuration, offset: float):
+def given_touch_offset(touch: TouchMode, config: Configuration, offset: float):
     config.save_touch_model(replace(config.touch.models["default"], z_offset=offset))
-    probe.touch.load_model("default")
+    touch.load_model("default")

--- a/tests/bdd/step_definitions/macros/test_z_offset.py
+++ b/tests/bdd/step_definitions/macros/test_z_offset.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from pytest_bdd import given, parsers, scenarios, then, when
 
 from cartographer.interfaces.printer import HomingState
+from cartographer.macros.touch import TouchHomeMacro
 
 if TYPE_CHECKING:
     from pytest import LogCaptureFixture
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from cartographer.interfaces.configuration import Configuration
     from cartographer.interfaces.printer import MacroParams, Toolhead
     from cartographer.probe import Probe
+    from cartographer.probe.touch_mode import TouchMode
     from tests.bdd.helpers.context import Context
 
 
@@ -37,9 +39,11 @@ def given_g28(mocker: MockerFixture, probe: Probe):
 
 
 @given("I ran TOUCH_HOME")
-def given_touch_home(mocker: MockerFixture, probe: Probe):
-    homing_state = mocker.Mock(spec=HomingState, autospec=True)
-    probe.touch.on_home_end(homing_state)
+def given_touch_home(touch: TouchMode, toolhead: Toolhead, params: MacroParams):
+    macro = TouchHomeMacro(touch, toolhead, (10, 10))
+    macro.run(params)
+    # homing_state = mocker.Mock(spec=HomingState, autospec=True)
+    # probe.touch.on_home_end(homing_state)
 
 
 @when("I run the Z_OFFSET_APPLY_PROBE macro")


### PR DESCRIPTION
The `TOUCH_HOME` macro did not correctly inform the touch mode that homing had "ended", as it is not a standard klipper homing.
We call `on_home_end` to simply follow what `G28 Z` would do.