### PR TITLE
Add support for automatic mesh boundary calculations

### DIFF
--- a/src/cartographer/adapters/kalico/adapters.py
+++ b/src/cartographer/adapters/kalico/adapters.py
@@ -7,7 +7,7 @@ from cartographer.adapters.kalico.axis_twist_compensation import KalicoAxisTwist
 from cartographer.adapters.kalico.mcu_platform import KalicoMcuPlatform
 from cartographer.adapters.kalico.toolhead import KalicoToolhead
 from cartographer.adapters.klipper.bed_mesh import KlipperBedMesh
-from cartographer.adapters.klipper.configuration import KlipperConfiguration
+from cartographer.adapters.kalico.configuration import KalicoConfiguration
 from cartographer.adapters.klipper.gcode import KlipperGCodeDispatch
 from cartographer.adapters.klipper_like.scheduler import KlipperScheduler
 from cartographer.config.fields import parse
@@ -31,7 +31,7 @@ class KalicoAdapters(Adapters):
         general = parse(GeneralConfig, config)
         platform = KalicoMcuPlatform(config, general.mcu)
         self.mcu = CartographerMcu(platform, self.scheduler)
-        self.config = KlipperConfiguration(config, self.mcu, general)
+        self.config = KalicoConfiguration(config, self.mcu, general)
 
         self.toolhead = KalicoToolhead(config, self.mcu)
         self.bed_mesh = KlipperBedMesh(config)

--- a/src/cartographer/adapters/kalico/configuration.py
+++ b/src/cartographer/adapters/kalico/configuration.py
@@ -159,11 +159,11 @@ class KalicoConfiguration(Configuration):
             # TODO: Add relevant type information
             printer_info = self._printer.lookup_object("printer_info")
 
-            mesh_min, mesh_max = printer_info.calculate_bed_corners(
+            mesh_min, mesh_max = printer_info.get_mesh_bounds(
                 mesh_min,
                 mesh_max,
-                True,
-                lambda msg: self._printer.config_error(msg),
+                use_offsets=True,
+                error=self._printer.config_error,
                 probe_offset=(self.general.x_offset, self.general.y_offset),
             )
 

--- a/src/cartographer/adapters/kalico/configuration.py
+++ b/src/cartographer/adapters/kalico/configuration.py
@@ -162,9 +162,9 @@ class KalicoConfiguration(Configuration):
             mesh_min, mesh_max = printer_info.calculate_bed_corners(
                 mesh_min,
                 mesh_max,
-                (self.general.x_offset, self.general.y_offset),
                 True,
                 lambda msg: self._printer.config_error(msg),
+                probe_offset=(self.general.x_offset, self.general.y_offset),
             )
 
         return mesh_min, mesh_max

--- a/src/cartographer/adapters/kalico/configuration.py
+++ b/src/cartographer/adapters/kalico/configuration.py
@@ -21,6 +21,9 @@ from cartographer.interfaces.configuration import (
     TouchModelConfiguration,
 )
 
+# TODO: Consider deduplicating through inheritance or delegation
+# from ..klipper.configuration import KlipperConfiguration
+
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
 
@@ -28,16 +31,16 @@ if TYPE_CHECKING:
 
 
 @final
-class KlipperConfiguration(Configuration):
+class KalicoConfiguration(Configuration):
     def __init__(self, config: ConfigWrapper, mcu: CartographerMcu, general: GeneralConfig) -> None:
         self.wrapper = config
         self._mcu = mcu
         self._config = config.get_printer().lookup_object("configfile")
+        self._printer = config.get_printer()
 
         self.name = config.get_name()
 
-        endstop_pin = f"{general.endstop_chip_name}:z_virtual_endstop"
-        self._validate_stepper_z(endstop_pin)
+        self._validate_stepper_z()
 
         self.general = general
         self.coil = parse(CoilConfiguration, config.getsection("cartographer coil"))
@@ -134,11 +137,11 @@ class KlipperConfiguration(Configuration):
     def log_runtime_warning(self, message: str) -> None:
         return self._config.runtime_warning(message)
 
-    def _validate_stepper_z(self, endstop_pin: str) -> None:
+    def _validate_stepper_z(self) -> None:
         if not self.wrapper.has_section("stepper_z"):
             return
         stepper_z = self.wrapper.getsection("stepper_z")
-        if stepper_z.get("endstop_pin", default=None) != endstop_pin:
+        if stepper_z.get("endstop_pin", default=None) != "probe:z_virtual_endstop":
             return
 
         homing_retract_dist = stepper_z.getfloat("homing_retract_dist", default=None, note_valid=False)
@@ -148,7 +151,20 @@ class KlipperConfiguration(Configuration):
 
     @override
     def mesh_bounds(self) -> tuple[tuple[float, float], tuple[float, float]]:
-        if self.bed_mesh.mesh_min is None or self.bed_mesh.mesh_max is None:
-            raise ValueError("Missing mesh bounds: 'mesh_min' and 'mesh_max' must be set in bed mesh configuration")
+        mesh_min = self.bed_mesh.mesh_min
+        mesh_max = self.bed_mesh.mesh_max
 
-        return self.bed_mesh.mesh_min, self.bed_mesh.mesh_max
+        # TODO: These values could be cached after the first calculation
+        if mesh_min is None or mesh_max is None:
+            # TODO: Add relevant type information
+            printer_info = self._printer.lookup_object("printer_info")
+
+            mesh_min, mesh_max = printer_info.calculate_bed_corners(
+                mesh_min,
+                mesh_max,
+                (self.general.x_offset, self.general.y_offset),
+                True,
+                lambda msg: self._printer.config_error(msg),
+            )
+
+        return mesh_min, mesh_max

--- a/src/cartographer/adapters/kalico/configuration.py
+++ b/src/cartographer/adapters/kalico/configuration.py
@@ -21,42 +21,26 @@ from cartographer.interfaces.configuration import (
     TouchModelConfiguration,
 )
 
+# TODO: Consider deduplicating through inheritance or delegation
+# from ..klipper.configuration import KlipperConfiguration
+
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
 
     from cartographer.mcu.mcu import CartographerMcu
 
 
-def parse_touch_model_with_defaults(
-    config: ConfigWrapper,
-    *,
-    global_samples: int,
-    global_sample_range: float,
-) -> TouchModelConfiguration:
-    """Parse a touch model section, inheriting global touch defaults for missing keys.
-
-    Reads ``samples`` and ``sample_range`` from the model section directly using the
-    same constraints as the global ``[cartographer touch]`` definition.  When a key is
-    absent the global value is used, so every in-memory model always carries concrete
-    (non-None) values regardless of whether the config file was written before these
-    options were introduced.
-    """
-    samples = config.getint("samples", default=global_samples, minval=3)
-    sample_range = config.getfloat("sample_range", default=global_sample_range, minval=0.001, maxval=0.015)
-    return parse(TouchModelConfiguration, config, samples=samples, sample_range=sample_range)
-
-
 @final
-class KlipperConfiguration(Configuration):
+class KalicoConfiguration(Configuration):
     def __init__(self, config: ConfigWrapper, mcu: CartographerMcu, general: GeneralConfig) -> None:
         self.wrapper = config
         self._mcu = mcu
         self._config = config.get_printer().lookup_object("configfile")
+        self._printer = config.get_printer()
 
         self.name = config.get_name()
 
-        endstop_pin = f"{general.endstop_chip_name}:z_virtual_endstop"
-        self._validate_stepper_z(endstop_pin)
+        self._validate_stepper_z()
 
         self.general = general
         self.coil = parse(CoilConfiguration, config.getsection("cartographer coil"))
@@ -71,19 +55,11 @@ class KlipperConfiguration(Configuration):
         self.scan = parse(ScanConfig, config.getsection(f"{self.name} scan"), models=scan_models)
 
         self.touch_model_prefix = f"{self.name} touch_model"
-        # Parse global touch section first to obtain inherited defaults, with an
-        # empty models dict. Model sections are parsed below with the resolved
-        # global values as fallbacks so every model has concrete samples/sample_range.
-        _touch_global = parse(TouchConfig, config.getsection(f"{self.name} touch"), models={})
         touch_models = {
-            wrapper.get_name().split(" ")[-1]: parse_touch_model_with_defaults(
-                wrapper,
-                global_samples=_touch_global.samples,
-                global_sample_range=_touch_global.sample_range,
-            )
+            wrapper.get_name().split(" ")[-1]: parse(TouchModelConfiguration, wrapper)
             for wrapper in config.get_prefix_sections(self.touch_model_prefix)
         }
-        self.touch = replace(_touch_global, models=touch_models)
+        self.touch = parse(TouchConfig, config.getsection(f"{self.name} touch"), models=touch_models)
 
     @override
     def save_scan_model(self, config: ScanModelConfiguration) -> None:
@@ -124,8 +100,6 @@ class KlipperConfiguration(Configuration):
         save(_key("threshold"), config.threshold)
         save(_key("speed"), config.speed)
         save(_key("z_offset"), round(config.z_offset, 3))
-        save(_key("samples"), config.samples)
-        save(_key("sample_range"), round(config.sample_range, 4))
 
         # Version info fields are part of ModelVersionInfo, not individual option() fields
         sw_version = __version__
@@ -163,11 +137,11 @@ class KlipperConfiguration(Configuration):
     def log_runtime_warning(self, message: str) -> None:
         return self._config.runtime_warning(message)
 
-    def _validate_stepper_z(self, endstop_pin: str) -> None:
+    def _validate_stepper_z(self) -> None:
         if not self.wrapper.has_section("stepper_z"):
             return
         stepper_z = self.wrapper.getsection("stepper_z")
-        if stepper_z.get("endstop_pin", default=None) != endstop_pin:
+        if stepper_z.get("endstop_pin", default=None) != "probe:z_virtual_endstop":
             return
 
         homing_retract_dist = stepper_z.getfloat("homing_retract_dist", default=None, note_valid=False)
@@ -177,7 +151,20 @@ class KlipperConfiguration(Configuration):
 
     @override
     def mesh_bounds(self) -> tuple[tuple[float, float], tuple[float, float]]:
-        if self.bed_mesh.mesh_min is None or self.bed_mesh.mesh_max is None:
-            raise ValueError("Missing mesh bounds: 'mesh_min' and 'mesh_max' must be set in bed mesh configuration")
+        mesh_min = self.bed_mesh.mesh_min
+        mesh_max = self.bed_mesh.mesh_max
 
-        return self.bed_mesh.mesh_min, self.bed_mesh.mesh_max
+        # TODO: These values could be cached after the first calculation
+        if mesh_min is None or mesh_max is None:
+            # TODO: Add relevant type information
+            printer_info = self._printer.lookup_object("printer_info")
+
+            mesh_min, mesh_max = printer_info.calculate_bed_corners(
+                mesh_min,
+                mesh_max,
+                (self.general.x_offset, self.general.y_offset),
+                True,
+                lambda msg: self._printer.config_error(msg),
+            )
+
+        return mesh_min, mesh_max

--- a/src/cartographer/adapters/kalico/probe.py
+++ b/src/cartographer/adapters/kalico/probe.py
@@ -28,12 +28,16 @@ class KalicoCartographerProbe:
         self.toolhead = toolhead
 
         self.lift_speed = config.lift_speed
+        self.min_edge_distance = config.min_edge_distance
         self.sample_count = 1
         self.samples_tolerance = 0.1
         self.samples_retries = 0
 
     def get_offsets(self) -> tuple[float, float, float]:
         return self.probe.offset.as_tuple()
+
+    def get_min_edge_distance(self) -> float | None:
+        return self.min_edge_distance
 
     def get_status(self, eventtime: float):
         del eventtime

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -256,16 +256,6 @@ class TouchConfig:
 class BedMeshConfig:
     config_section_key: ClassVar[str] = "bed_mesh"
 
-    mesh_min: tuple[float, float] | None = option(
-        "Minimum coordinates of the mesh area.",
-        parse_fn=_parse_mesh_min,
-        default=None,
-    )
-    mesh_max: tuple[float, float] | None = option(
-        "Maximum coordinates of the mesh area.",
-        parse_fn=_parse_mesh_max,
-        default=None,
-    )
     probe_count: tuple[int, int] = option(
         "Number of probe points in X and Y.",
         parse_fn=_parse_probe_count,
@@ -277,6 +267,16 @@ class BedMeshConfig:
     faulty_regions: list[Region] = option(
         "Regions to exclude from mesh probing.",
         parse_fn=_parse_faulty_regions,
+    )
+    mesh_min: tuple[float, float] | None = option(
+        "Minimum coordinates of the mesh area.",
+        parse_fn=_parse_mesh_min,
+        default=None,
+    )
+    mesh_max: tuple[float, float] | None = option(
+        "Maximum coordinates of the mesh area.",
+        parse_fn=_parse_mesh_max,
+        default=None,
     )
     speed: float = option("Travel speed during mesh probing.", default=50, min=1)
     horizontal_move_z: float = option("Z height for horizontal moves during mesh.", default=5, min=1)

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -178,6 +178,9 @@ class GeneralConfig:
         " and does not claim the 'probe' object, allowing a separate [probe] section to coexist.",
         default=True,
     )
+    min_edge_distance: float | None = option(
+        "Minimum distance (in mm) from the edge of the bed to the center of the probe when probing.", default=None
+    )
 
     @property
     def endstop_chip_name(self) -> str:
@@ -253,13 +256,15 @@ class TouchConfig:
 class BedMeshConfig:
     config_section_key: ClassVar[str] = "bed_mesh"
 
-    mesh_min: tuple[float, float] = option(
+    mesh_min: tuple[float, float] | None = option(
         "Minimum coordinates of the mesh area.",
         parse_fn=_parse_mesh_min,
+        default=None,
     )
-    mesh_max: tuple[float, float] = option(
+    mesh_max: tuple[float, float] | None = option(
         "Maximum coordinates of the mesh area.",
         parse_fn=_parse_mesh_max,
+        default=None,
     )
     probe_count: tuple[int, int] = option(
         "Number of probe points in X and Y.",
@@ -360,3 +365,4 @@ class Configuration(Protocol):
     def remove_touch_model(self, name: str) -> None: ...
     def save_z_backlash(self, backlash: float) -> None: ...
     def log_runtime_warning(self, message: str) -> None: ...
+    def mesh_bounds(self) -> tuple[tuple[float, float], tuple[float, float]]: ...

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -65,6 +65,7 @@ def _parse_mesh_max(config: ConfigWrapper) -> tuple[float, float] | None:
 
     return _list_to_tuple(result)
 
+
 def _parse_probe_count(config: ConfigWrapper) -> tuple[int, int]:
     return _list_to_int_tuple(config.getintlist("probe_count", count=2))
 

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -50,13 +50,20 @@ def _list_to_int_tuple(lst: list[int]) -> tuple[int, int]:
     return (lst[0], lst[1])
 
 
-def _parse_mesh_min(config: ConfigWrapper) -> tuple[float, float]:
-    return _list_to_tuple(config.getfloatlist("mesh_min", count=2))
+def _parse_mesh_min(config: ConfigWrapper) -> tuple[float, float] | None:
+    result = config.getfloatlist("mesh_min", count=2, default=None)
+    if result is None:
+        return None
+
+    return _list_to_tuple(result)
 
 
-def _parse_mesh_max(config: ConfigWrapper) -> tuple[float, float]:
-    return _list_to_tuple(config.getfloatlist("mesh_max", count=2))
+def _parse_mesh_max(config: ConfigWrapper) -> tuple[float, float] | None:
+    result = config.getfloatlist("mesh_max", count=2, default=None)
+    if result is None:
+        return None
 
+    return _list_to_tuple(result)
 
 def _parse_probe_count(config: ConfigWrapper) -> tuple[int, int]:
     return _list_to_int_tuple(config.getintlist("probe_count", count=2))

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -178,6 +178,9 @@ class GeneralConfig:
         " and does not claim the 'probe' object, allowing a separate [probe] section to coexist.",
         default=True,
     )
+    min_edge_distance: float | None = option(
+        "Minimum distance (in mm) from the edge of the bed to the center of the probe when probing.", default=None
+    )
 
     @property
     def endstop_chip_name(self) -> str:
@@ -253,13 +256,15 @@ class TouchConfig:
 class BedMeshConfig:
     config_section_key: ClassVar[str] = "bed_mesh"
 
-    mesh_min: tuple[float, float] = option(
+    mesh_min: tuple[float, float] | None = option(
         "Minimum coordinates of the mesh area.",
         parse_fn=_parse_mesh_min,
+        default=None,
     )
-    mesh_max: tuple[float, float] = option(
+    mesh_max: tuple[float, float] | None = option(
         "Maximum coordinates of the mesh area.",
         parse_fn=_parse_mesh_max,
+        default=None,
     )
     probe_count: tuple[int, int] = option(
         "Number of probe points in X and Y.",
@@ -362,3 +367,4 @@ class Configuration(Protocol):
     def remove_touch_model(self, name: str) -> None: ...
     def save_z_backlash(self, backlash: float) -> None: ...
     def log_runtime_warning(self, message: str) -> None: ...
+    def mesh_bounds(self) -> tuple[tuple[float, float], tuple[float, float]]: ...

--- a/src/cartographer/macros/bed_mesh/scan_mesh.py
+++ b/src/cartographer/macros/bed_mesh/scan_mesh.py
@@ -72,8 +72,8 @@ def _get_max_corner_radius(params: MacroParams, config_default: float | None) ->
 
 @dataclass(frozen=True)
 class BedMeshCalibrateConfiguration:
-    mesh_min: tuple[float, float]
-    mesh_max: tuple[float, float]
+    _config: Configuration
+
     probe_count: tuple[int, int]
     speed: float
     adaptive_margin: float
@@ -89,8 +89,7 @@ class BedMeshCalibrateConfiguration:
     @staticmethod
     def from_config(config: Configuration):
         return BedMeshCalibrateConfiguration(
-            mesh_min=config.bed_mesh.mesh_min,
-            mesh_max=config.bed_mesh.mesh_max,
+            _config=config,
             probe_count=config.bed_mesh.probe_count,
             speed=config.bed_mesh.speed,
             adaptive_margin=config.bed_mesh.adaptive_margin,
@@ -102,6 +101,15 @@ class BedMeshCalibrateConfiguration:
             max_corner_radius=config.scan.mesh_max_corner_radius,
             faulty_regions=list(map(lambda r: Region(r[0], r[1]), config.bed_mesh.faulty_regions)),
         )
+
+    # TODO: Explain why it is the way it is
+    @property
+    def mesh_min(self) -> tuple[float, float]:
+        return self._config.mesh_bounds()[0]
+
+    @property
+    def mesh_max(self) -> tuple[float, float]:
+        return self._config.mesh_bounds()[1]
 
 
 _directions: list[str] = ["x", "y"]

--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -42,14 +42,14 @@ class TouchModeConfiguration:
 
     x_offset: float
     y_offset: float
-    mesh_min: tuple[float, float]
-    mesh_max: tuple[float, float]
     max_touch_temperature: int
     lift_speed: float
 
     retract_distance: float
     models: dict[str, TouchModelConfiguration]
     sample_range: float
+
+    _config: Configuration
 
     @staticmethod
     def from_config(config: Configuration):
@@ -60,13 +60,21 @@ class TouchModeConfiguration:
             models=config.touch.models,
             x_offset=config.general.x_offset,
             y_offset=config.general.y_offset,
-            mesh_min=config.bed_mesh.mesh_min,
-            mesh_max=config.bed_mesh.mesh_max,
+            _config=config,
             max_touch_temperature=config.touch.max_touch_temperature,
             lift_speed=config.general.lift_speed,
             retract_distance=config.touch.retract_distance,
             sample_range=config.touch.sample_range,
         )
+
+    # TODO: Both can be resolved here now
+    @property
+    def mesh_min(self) -> tuple[float, float]:
+        return self._config.mesh_bounds()[0]
+
+    @property
+    def mesh_max(self) -> tuple[float, float]:
+        return self._config.mesh_bounds()[1]
 
 
 class TouchError(RuntimeError):
@@ -220,8 +228,16 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
         self._mcu: Mcu = mcu
         self._config: TouchModeConfiguration = config
 
-        self.boundaries: TouchBoundaries = TouchBoundaries.from_config(config)
+        self._boundaries: TouchBoundaries | None = None
         self.last_z_result: float | None = None
+
+    @property
+    def boundaries(self) -> TouchBoundaries:
+        # TODO: Explain why this is the way it is
+        if self._boundaries is None:
+            self._boundaries = TouchBoundaries.from_config(self._config)
+
+        return self._boundaries
 
     @override
     def get_status(self, eventtime: float) -> dict[str, object]:

--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -43,14 +43,14 @@ class TouchModeConfiguration:
 
     x_offset: float
     y_offset: float
-    mesh_min: tuple[float, float]
-    mesh_max: tuple[float, float]
     max_touch_temperature: int
     lift_speed: float
 
     retract_distance: float
     models: dict[str, TouchModelConfiguration]
     sample_range: float
+
+    _config: Configuration
 
     @staticmethod
     def from_config(config: Configuration) -> TouchModeConfiguration:
@@ -61,13 +61,21 @@ class TouchModeConfiguration:
             models=config.touch.models,
             x_offset=config.general.x_offset,
             y_offset=config.general.y_offset,
-            mesh_min=config.bed_mesh.mesh_min,
-            mesh_max=config.bed_mesh.mesh_max,
+            _config=config,
             max_touch_temperature=config.touch.max_touch_temperature,
             lift_speed=config.general.lift_speed,
             retract_distance=config.touch.retract_distance,
             sample_range=config.touch.sample_range,
         )
+
+    # TODO: Both can be resolved here now
+    @property
+    def mesh_min(self) -> tuple[float, float]:
+        return self._config.mesh_bounds()[0]
+
+    @property
+    def mesh_max(self) -> tuple[float, float]:
+        return self._config.mesh_bounds()[1]
 
 
 class TouchError(RuntimeError):
@@ -221,8 +229,16 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
         self._mcu: Mcu = mcu
         self._config: TouchModeConfiguration = config
 
-        self.boundaries: TouchBoundaries = TouchBoundaries.from_config(config)
+        self._boundaries: TouchBoundaries | None = None
         self.last_z_result: float | None = None
+
+    @property
+    def boundaries(self) -> TouchBoundaries:
+        # TODO: Explain why this is the way it is
+        if self._boundaries is None:
+            self._boundaries = TouchBoundaries.from_config(self._config)
+
+        return self._boundaries
 
     @override
     def get_status(self, eventtime: float) -> dict[str, object]:


### PR DESCRIPTION
My PR https://github.com/KalicoCrew/kalico/pull/879 needs support in cartographer, because the meshing and config parsing does not delegate to the bed_mesh implementation in kalico. The axis twist code should work out-of-the-box, because that one should delegate to the kalico implementation. Technically it does not at the moment, I will have to update my Kalico PR...

This PR is a work-in-progress, for now I will test it with my kalico fork on my printer and update this PR based on the results.
After the Kalico PR is merged, I will update this PR.

### Why the implementation is the way it is?

For correctly calculating the mesh bounds, one must know where the printer can move to. This is defined in the `toolhead` object. This class is loaded after all extras/sections, and the `printer_info` depends on it, so it can only be accessed after for example a connect.

The current cartographer code parses everything on load and assumes mesh_min/mesh_max are available too. To resolve this issue, I updated the configuration class, which now has a method for resolving the bounds. The other classes have been updated to call this function, and everything has been adjusted to ensure that these properties are only accessed when they can be resolved (hopefully).

### Todo

- [ ] Set a sensible default value for min_edge_distance. 0 is not good
- [ ] Make sure the code crashes if min_edge_distance is not set, and mesh_min/mesh_max are not set either