### PR TITLE
fix(touch): abort probing at movement floor

### DIFF
--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 TOUCH_ACCEL = 100
 MAX_TOUCH_TEMPERATURE_EPSILON = 2
+_TOUCH_FLOOR_TOLERANCE = 0.001
 
 
 @dataclass(frozen=True)
@@ -278,6 +279,13 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
             z=max(pos.z + self._config.retract_distance, self._config.retract_distance),
             speed=self._config.lift_speed,
         )
+
+        z_min, _ = self._toolhead.get_axis_limits("z")
+        if trigger_pos <= z_min + _TOUCH_FLOOR_TOLERANCE:
+            self._toolhead.wait_moves()
+            msg = f"Probe triggered at or near the Z movement floor (z={trigger_pos:.6f}, floor={z_min:.6f})"
+            raise RuntimeError(msg)
+
         return trigger_pos - model.z_offset
 
     @override

--- a/tests/macros/test_z_offset_macros.py
+++ b/tests/macros/test_z_offset_macros.py
@@ -12,6 +12,7 @@ from cartographer.macros.touch import TouchHomeMacro
 
 if TYPE_CHECKING:
     from pytest import LogCaptureFixture
+    from pytest_mock import MockerFixture
 
     from cartographer.interfaces.configuration import Configuration
     from cartographer.interfaces.printer import MacroParams, Toolhead
@@ -50,7 +51,7 @@ def calibrated_scan(scan: ScanMode, config: Configuration, session: Session[Samp
 
 
 @pytest.fixture
-def calibrated_touch(touch: TouchMode, config: Configuration):
+def calibrated_touch(touch: TouchMode, config: Configuration, toolhead: Toolhead, mocker: MockerFixture):
     """Fixture to setup a calibrated touch mode."""
     config.touch.models["default"] = TouchModelConfiguration(
         name="default",
@@ -59,6 +60,7 @@ def calibrated_touch(touch: TouchMode, config: Configuration):
         z_offset=0.0,
     )
     touch.load_model("default")
+    toolhead.get_axis_limits = mocker.Mock(return_value=(-5, 100))
     return touch
 
 

--- a/tests/probes/test_touch_probe.py
+++ b/tests/probes/test_touch_probe.py
@@ -45,6 +45,7 @@ def test_probe_includes_z_offset(
         )
     )
     probe.touch.load_model("test_touch")
+    toolhead.get_axis_limits = mocker.Mock(return_value=(-5, 100))
     toolhead.z_probing_move = mocker.Mock(return_value=-0.5)
     toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
 
@@ -110,6 +111,32 @@ def test_probe_unhomed_z(mocker: MockerFixture, toolhead: Toolhead, probe: Probe
 
     with pytest.raises(RuntimeError, match="Z axis must be homed"):
         _ = probe.touch.perform_probe()
+
+
+@pytest.mark.parametrize("trigger_z", [-5.0, -4.999], ids=["exact_floor", "inclusive_boundary"])
+def test_floor_abort_retract_then_wait_raises(
+    mocker: MockerFixture, toolhead: Toolhead, probe: Probe, trigger_z: float
+) -> None:
+    """Retract queued after floor hit, wait_moves completes it, then RuntimeError raised."""
+    toolhead.get_axis_limits = mocker.Mock(return_value=(-5, 100))
+    toolhead.z_probing_move = mocker.Mock(return_value=trigger_z)
+    toolhead.get_position = mocker.Mock(
+        side_effect=[
+            Position(0, 0, 2),
+            Position(0, 0, 2),
+            Position(0, 0, trigger_z),
+        ]
+    )
+    move_counts: list[int] = []
+    move_spy = mocker.spy(toolhead, "move")
+    wait_spy = mocker.spy(toolhead, "wait_moves")
+    wait_spy.side_effect = lambda: move_counts.append(move_spy.call_count)
+
+    with pytest.raises(RuntimeError, match="movement floor"):
+        _ = probe.touch.perform_probe()
+
+    move_spy.assert_called_once_with(z=2, speed=5)
+    assert move_counts == [0, 0, 1]
 
 
 def test_home_wait(mocker: MockerFixture, mcu: Mcu, probe: Probe) -> None:


### PR DESCRIPTION
## Reason / issue reference

Touch calibration and homing can treat repeated triggers at the configured Z movement floor as consistent samples, causing repeated bed strikes.

Closes #510

## Functional changes

Touch operations now abort when a trigger occurs at or within 0.001 mm of the configured Z movement floor. The normal upward retract completes before the error is raised, and the invalid result never reaches sampling or calibration threshold escalation.

The shared touch implementation applies this behavior to Klipper, Kalico, and SimpleAF.

## Decisions and callouts

The configured axis minimum is the reliable safety invariant. Negative Z alone is not treated as invalid because Z may be temporarily forced or inaccurately established. A plain `RuntimeError` is intentional so calibration and touch homing hard-abort instead of treating a floor hit as retryable.

## Install

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@fix/touch-movement-floor"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```