### PR TITLE
feat: allow fractional touch calibration speed

### DIFF
--- a/src/cartographer/macros/touch/calibrate.py
+++ b/src/cartographer/macros/touch/calibrate.py
@@ -229,7 +229,7 @@ class TouchCalibrateParams:
 
     max_verify_range: float = param("Maximum verification range")
     model: str = param("Model name", default=DEFAULT_TOUCH_MODEL_NAME)
-    speed: int = param("Probing speed", default=2, min=1, max=5)
+    speed: float = param("Probing speed", default=2.0, min=1, max=5)
     threshold_start: int = param("Starting threshold", default=500, min=100, key="START")
     threshold_max: int = param("Maximum threshold", default=5000, min=100, key="MAX")
     verification_samples: int = param("Verification sample count", default=10, min=3, max=20)
@@ -282,7 +282,7 @@ class TouchCalibrateMacro(Macro):
         required_samples = self._config.touch.samples
 
         logger.info(
-            "Starting touch calibration (speed=%d, range=%d-%d)",
+            "Starting touch calibration (speed=%g, range=%d-%d)",
             p.speed,
             p.threshold_start,
             p.threshold_max,
@@ -415,11 +415,11 @@ class TouchCalibrateMacro(Macro):
         self,
         name: str,
         threshold: int,
-        speed: int,
+        speed: float,
     ) -> None:
         """Save the calibration result and log success."""
         logger.info(
-            "Calibration complete: threshold=%d, speed=%d",
+            "Calibration complete: threshold=%d, speed=%g",
             threshold,
             speed,
         )

--- a/tests/macros/test_touch_calibrate.py
+++ b/tests/macros/test_touch_calibrate.py
@@ -4,15 +4,18 @@ import pytest
 from typing_extensions import final
 
 from cartographer.interfaces.errors import ProbeTriggerError
+from cartographer.macros.fields import parse
 from cartographer.macros.touch.calibrate import (
     ScreeningResult,
     ThresholdScreener,
     ThresholdVerifier,
+    TouchCalibrateParams,
     VerificationResult,
     calculate_step,
     format_distance,
 )
 from cartographer.probe.touch_mode import TouchError
+from tests.mocks.params import MockParams
 
 # --- Fake probe for testing ---
 
@@ -317,3 +320,19 @@ class TestCalculateStep:
         """Range just above 10x uses large step."""
         step = calculate_step(threshold=1000, range_value=0.101, sample_range=0.010)
         assert step == 200  # 0.101 > 10 * 0.010, uses 20%
+
+
+# --- TouchCalibrateParams ---
+
+
+class TestTouchCalibrateParams:
+    def test_fractional_speed_parsed_and_retained(self):
+        """CARTOGRAPHER_TOUCH_CALIBRATE SPEED=1.5 must parse to 1.5, not truncated."""
+        mock = MockParams()
+        mock.params["SPEED"] = "1.5"
+        p = parse(
+            TouchCalibrateParams,
+            mock,
+            max_verify_range=0.020,
+        )
+        assert p.speed == 1.5


### PR DESCRIPTION
## Reason / issue reference

Touch calibration currently rejects fractional probing speeds, preventing users from selecting values such as 1.5 mm/s.

Closes #507

## Functional changes

`CARTOGRAPHER_TOUCH_CALIBRATE` now accepts fractional `SPEED` values while preserving the existing default and 1–5 mm/s bounds.

## Decisions and callouts

The downstream calibration, model persistence, and toolhead APIs already support floats, so this change is limited to macro parsing, type consistency, logging, and regression coverage.

## Install

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@feat/fractional-touch-speed"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```