### PR TITLE
feat: persist touch calibration sampling profiles

### DIFF
--- a/src/cartographer/adapters/klipper/configuration.py
+++ b/src/cartographer/adapters/klipper/configuration.py
@@ -27,6 +27,25 @@ if TYPE_CHECKING:
     from cartographer.mcu.mcu import CartographerMcu
 
 
+def _parse_touch_model_with_defaults(
+    config: ConfigWrapper,
+    *,
+    global_samples: int,
+    global_sample_range: float,
+) -> TouchModelConfiguration:
+    """Parse a touch model section, inheriting global touch defaults for missing keys.
+
+    Reads ``samples`` and ``sample_range`` from the model section directly using the
+    same constraints as the global ``[cartographer touch]`` definition.  When a key is
+    absent the global value is used, so every in-memory model always carries concrete
+    (non-None) values regardless of whether the config file was written before these
+    options were introduced.
+    """
+    samples = config.getint("samples", default=global_samples, minval=3)
+    sample_range = config.getfloat("sample_range", default=global_sample_range, minval=0.001, maxval=0.015)
+    return parse(TouchModelConfiguration, config, samples=samples, sample_range=sample_range)
+
+
 @final
 class KlipperConfiguration(Configuration):
     def __init__(self, config: ConfigWrapper, mcu: CartographerMcu, general: GeneralConfig) -> None:
@@ -52,11 +71,19 @@ class KlipperConfiguration(Configuration):
         self.scan = parse(ScanConfig, config.getsection(f"{self.name} scan"), models=scan_models)
 
         self.touch_model_prefix = f"{self.name} touch_model"
+        # Parse global touch section first to obtain inherited defaults, with an
+        # empty models dict. Model sections are parsed below with the resolved
+        # global values as fallbacks so every model has concrete samples/sample_range.
+        _touch_global = parse(TouchConfig, config.getsection(f"{self.name} touch"), models={})
         touch_models = {
-            wrapper.get_name().split(" ")[-1]: parse(TouchModelConfiguration, wrapper)
+            wrapper.get_name().split(" ")[-1]: _parse_touch_model_with_defaults(
+                wrapper,
+                global_samples=_touch_global.samples,
+                global_sample_range=_touch_global.sample_range,
+            )
             for wrapper in config.get_prefix_sections(self.touch_model_prefix)
         }
-        self.touch = parse(TouchConfig, config.getsection(f"{self.name} touch"), models=touch_models)
+        self.touch = replace(_touch_global, models=touch_models)
 
     @override
     def save_scan_model(self, config: ScanModelConfiguration) -> None:
@@ -97,10 +124,8 @@ class KlipperConfiguration(Configuration):
         save(_key("threshold"), config.threshold)
         save(_key("speed"), config.speed)
         save(_key("z_offset"), round(config.z_offset, 3))
-        if config.samples is not None:
-            save(_key("samples"), config.samples)
-        if config.sample_range is not None:
-            save(_key("sample_range"), round(config.sample_range, 4))
+        save(_key("samples"), config.samples)
+        save(_key("sample_range"), round(config.sample_range, 4))
 
         # Version info fields are part of ModelVersionInfo, not individual option() fields
         sw_version = __version__

--- a/src/cartographer/adapters/klipper/configuration.py
+++ b/src/cartographer/adapters/klipper/configuration.py
@@ -97,6 +97,10 @@ class KlipperConfiguration(Configuration):
         save(_key("threshold"), config.threshold)
         save(_key("speed"), config.speed)
         save(_key("z_offset"), round(config.z_offset, 3))
+        if config.samples is not None:
+            save(_key("samples"), config.samples)
+        if config.sample_range is not None:
+            save(_key("sample_range"), round(config.sample_range, 4))
 
         # Version info fields are part of ModelVersionInfo, not individual option() fields
         sw_version = __version__

--- a/src/cartographer/adapters/klipper/configuration.py
+++ b/src/cartographer/adapters/klipper/configuration.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from cartographer.mcu.mcu import CartographerMcu
 
 
-def _parse_touch_model_with_defaults(
+def parse_touch_model_with_defaults(
     config: ConfigWrapper,
     *,
     global_samples: int,
@@ -76,7 +76,7 @@ class KlipperConfiguration(Configuration):
         # global values as fallbacks so every model has concrete samples/sample_range.
         _touch_global = parse(TouchConfig, config.getsection(f"{self.name} touch"), models={})
         touch_models = {
-            wrapper.get_name().split(" ")[-1]: _parse_touch_model_with_defaults(
+            wrapper.get_name().split(" ")[-1]: parse_touch_model_with_defaults(
                 wrapper,
                 global_samples=_touch_global.samples,
                 global_sample_range=_touch_global.sample_range,

--- a/src/cartographer/core.py
+++ b/src/cartographer/core.py
@@ -280,7 +280,7 @@ class PrinterCartographer:
                     ),
                     self._register_macro(
                         "TOUCH_PROBE",
-                        TouchProbeMacro(self.touch_mode, toolhead),
+                        TouchProbeMacro(self.touch_mode, toolhead, max_samples=self.config.touch.max_samples),
                     ),
                     self._register_macro(
                         "TOUCH_ACCURACY",

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -311,19 +311,8 @@ class TouchModelConfiguration:
     speed: float = option(min=1)
     z_offset: float = option(max=0)
     threshold: int = option(default=100)
-    samples: int | None = option(
-        "Override the number of samples for this model."
-        " When set, this takes precedence over the global [cartographer touch] samples setting.",
-        default=None,
-        min=3,
-    )
-    sample_range: float | None = option(
-        "Override the acceptable range between touch samples for this model."
-        " When set, this takes precedence over the global [cartographer touch] sample_range setting.",
-        default=None,
-        min=0.001,
-        max=0.015,
-    )
+    samples: int = option(default=3, min=3)
+    sample_range: float = option(default=0.010, min=0.001, max=0.015)
     version_info: ModelVersionInfo = option(
         default=ModelVersionInfo(),
         parse_fn=_parse_version_info,

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -311,6 +311,19 @@ class TouchModelConfiguration:
     speed: float = option(min=1)
     z_offset: float = option(max=0)
     threshold: int = option(default=100)
+    samples: int | None = option(
+        "Override the number of samples for this model."
+        " When set, this takes precedence over the global [cartographer touch] samples setting.",
+        default=None,
+        min=3,
+    )
+    sample_range: float | None = option(
+        "Override the acceptable range between touch samples for this model."
+        " When set, this takes precedence over the global [cartographer touch] sample_range setting.",
+        default=None,
+        min=0.001,
+        max=0.015,
+    )
     version_info: ModelVersionInfo = option(
         default=ModelVersionInfo(),
         parse_fn=_parse_version_info,

--- a/src/cartographer/macros/docs.py
+++ b/src/cartographer/macros/docs.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from cartographer.macros.axis_twist_compensation import AxisTwistCompensationMacro, AxisTwistParams
 from cartographer.macros.backlash import EstimateBacklashMacro, EstimateBacklashParams
 from cartographer.macros.bed_mesh.scan_mesh import BedMeshCalibrateMacro, BedMeshScanAllParams
-from cartographer.macros.fields import ConfigRef, ParamInfo, get_all_params
+from cartographer.macros.fields import ComputedDefault, ConfigRef, ParamInfo, get_all_params
 from cartographer.macros.model_manager import ModelManagerParams, ScanModelManager, TouchModelManager
 from cartographer.macros.probe import (
     ProbeAccuracyMacro,
@@ -67,6 +67,8 @@ MACROS: list[tuple[str, type[Macro], type]] = [
 
 def _format_default(value: object) -> str:
     """Format a default value for display in docs."""
+    if isinstance(value, ComputedDefault):
+        return f"computed: {value.display}"
     if isinstance(value, ConfigRef):
         return f"config '{value.option_name}'"
     if isinstance(value, bool):
@@ -118,8 +120,8 @@ def _format_example_value(p: ParamInfo) -> str:
     """Format a parameter value for the example line."""
     if p.required:
         return f"<{p.name.lower()}>"
-    if isinstance(p.default, ConfigRef):
-        return f"<{p.name.lower()}>"
+    if isinstance(p.default, (ConfigRef, ComputedDefault)):
+        return f"<{p.name.lower()}>" if isinstance(p.default, ConfigRef) else ""
     if isinstance(p.default, bool):
         return "yes" if p.default else "no"
     if isinstance(p.default, Enum):

--- a/src/cartographer/macros/fields.py
+++ b/src/cartographer/macros/fields.py
@@ -26,6 +26,34 @@ _PARAM_METADATA_KEY = "_macro_param"
 
 
 @dataclass(frozen=True)
+class ComputedDefault:
+    """Sentinel marking a macro param default as dynamically computed at runtime.
+
+    At parse time the actual value is supplied via ``**defaults``; this sentinel
+    carries only a human-readable expression so docs can render
+    ``computed: <display>`` instead of marking the parameter as required.
+    """
+
+    display: str
+
+
+def computed_default(display: str) -> ComputedDefault:
+    """Create a computed-default sentinel for a macro param.
+
+    The returned sentinel marks a parameter whose default is computed
+    dynamically at runtime (e.g. derived from another parameter's value).
+    Docs will render ``computed: <display>`` so callers understand what
+    drives the value.  The actual runtime default must still be provided
+    via ``parse(..., **defaults)``.
+
+    Args:
+        display: Human-readable expression describing the computation,
+            e.g. ``"2 × effective SAMPLE_RANGE"``.
+    """
+    return ComputedDefault(display=display)
+
+
+@dataclass(frozen=True)
 class ConfigRef:
     """Sentinel marking a macro param default as derived from a config option.
 
@@ -94,6 +122,17 @@ class _ParamMeta:
             max=self.max,
             key=self.key,
         )
+
+
+@overload
+def param(
+    description: str | None = ...,
+    *,
+    default: ComputedDefault,
+    key: str | None = ...,
+    min: float | None = ...,
+    max: float | None = ...,
+) -> Any: ...
 
 
 @overload
@@ -341,9 +380,9 @@ def parse(cls: type[T], params: MacroParams, **defaults: Any) -> T:
         effective_meta = meta.field_meta
         if f.name in defaults:
             effective_meta = dataclasses.replace(effective_meta, default=defaults[f.name])
-        elif isinstance(meta.default, ConfigRef):
-            # ConfigRef is a docs sentinel — at runtime the caller MUST supply the
-            # actual config value via **defaults.  Treat as required if missing.
+        elif isinstance(meta.default, (ConfigRef, ComputedDefault)):
+            # ConfigRef / ComputedDefault are docs sentinels — at runtime the caller
+            # MUST supply the actual value via **defaults.  Treat as required if missing.
             effective_meta = dataclasses.replace(effective_meta, default=MISSING)
 
         type_hint = hints[f.name]

--- a/src/cartographer/macros/touch/calibrate.py
+++ b/src/cartographer/macros/touch/calibrate.py
@@ -555,7 +555,14 @@ class CalibrationTouchMode(TouchMode):
         threshold: int,
         speed: float,
     ) -> None:
-        model = TouchModelConfiguration(name="calibration", threshold=threshold, speed=speed, z_offset=0)
+        model = TouchModelConfiguration(
+            name="calibration",
+            threshold=threshold,
+            speed=speed,
+            z_offset=0,
+            samples=config.samples,
+            sample_range=config.sample_range,
+        )
         super().__init__(
             mcu,
             toolhead,

--- a/src/cartographer/macros/touch/calibrate.py
+++ b/src/cartographer/macros/touch/calibrate.py
@@ -10,11 +10,12 @@ from typing_extensions import Protocol, override, runtime_checkable
 
 from cartographer.interfaces.configuration import (
     Configuration,
+    TouchConfig,
     TouchModelConfiguration,
 )
 from cartographer.interfaces.errors import ProbeTriggerError
 from cartographer.interfaces.printer import Macro, MacroParams, Mcu
-from cartographer.macros.fields import param, parse
+from cartographer.macros.fields import computed_default, config_ref, param, parse
 from cartographer.macros.utils import force_home_z
 from cartographer.probe.touch_mode import (
     TouchError,
@@ -22,7 +23,6 @@ from cartographer.probe.touch_mode import (
     TouchModeConfiguration,
     compute_range,
     find_best_subset,
-    run_probe_sequence,
 )
 
 if TYPE_CHECKING:
@@ -227,7 +227,23 @@ class ThresholdVerifier:
 class TouchCalibrateParams:
     """Parameters for CARTOGRAPHER_TOUCH_CALIBRATE."""
 
-    max_verify_range: float = param("Maximum verification range")
+    max_verify_range: float = param(
+        "Maximum verification range between touch-probe medians."
+        " Must be at least effective SAMPLE_RANGE and at most 4 \u00d7 effective SAMPLE_RANGE."
+        " Defaults to 2 \u00d7 effective SAMPLE_RANGE when not specified.",
+        default=computed_default("2 \u00d7 effective SAMPLE_RANGE"),
+    )
+    samples: int = param(
+        "Number of samples per probe sequence. Cannot exceed configured [cartographer touch] max_samples.",
+        default=config_ref(TouchConfig, "samples"),
+        min=3,
+    )
+    sample_range: float = param(
+        "Acceptable range between touch samples",
+        default=config_ref(TouchConfig, "sample_range"),
+        min=0.001,
+        max=0.015,
+    )
     model: str = param("Model name", default=DEFAULT_TOUCH_MODEL_NAME)
     speed: float = param("Probing speed", default=2.0, min=1, max=5)
     threshold_start: int = param("Starting threshold", default=500, min=100, key="START")
@@ -255,22 +271,37 @@ class TouchCalibrateMacro(Macro):
 
     @override
     def run(self, params: MacroParams) -> None:
-        sample_range = self._config.touch.sample_range
+        # Pre-extract effective sample_range so its value can drive the
+        # MAX_VERIFY_RANGE default before the full parameter parse.
+        effective_sample_range = params.get_float(
+            "SAMPLE_RANGE",
+            default=self._config.touch.sample_range,
+            minval=0.001,
+            maxval=0.015,
+        )
         p = parse(
             TouchCalibrateParams,
             params,
-            max_verify_range=self._config.touch.sample_range * 2,
+            samples=self._config.touch.samples,
+            sample_range=self._config.touch.sample_range,
+            max_verify_range=effective_sample_range * 2,
         )
         name = p.model.lower()
 
         if p.threshold_max < p.threshold_start:
             msg = f"MAX ({p.threshold_max}) must be >= START ({p.threshold_start})"
             raise RuntimeError(msg)
-        if p.max_verify_range < sample_range:
-            msg = f"MAX_VERIFY_RANGE ({p.max_verify_range}) must be >= sample_range ({sample_range})"
+        if p.samples > self._config.touch.max_samples:
+            msg = (
+                f"SAMPLES ({p.samples}) exceeds the configured max_samples ({self._config.touch.max_samples})."
+                f" Reduce SAMPLES or increase max_samples in [cartographer touch]."
+            )
             raise RuntimeError(msg)
-        if p.max_verify_range > sample_range * 4:
-            msg = f"MAX_VERIFY_RANGE ({p.max_verify_range}) must be <= sample_range * 4 ({sample_range * 4})"
+        if p.max_verify_range < p.sample_range:
+            msg = f"MAX_VERIFY_RANGE ({p.max_verify_range}) must be >= SAMPLE_RANGE ({p.sample_range})"
+            raise RuntimeError(msg)
+        if p.max_verify_range > p.sample_range * 4:
+            msg = f"MAX_VERIFY_RANGE ({p.max_verify_range}) must be <= SAMPLE_RANGE * 4 ({p.sample_range * 4})"
             raise RuntimeError(msg)
 
         if not self._toolhead.is_homed("x") or not self._toolhead.is_homed("y"):
@@ -278,8 +309,6 @@ class TouchCalibrateMacro(Macro):
             raise RuntimeError(msg)
 
         self._move_to_calibration_position()
-
-        required_samples = self._config.touch.samples
 
         logger.info(
             "Starting touch calibration (speed=%g, range=%d-%d)",
@@ -289,22 +318,33 @@ class TouchCalibrateMacro(Macro):
         )
         logger.info(
             "Screening: %d samples within %smm range. Verification: %d samples within %smm range",
-            required_samples,
-            format_distance(sample_range),
+            p.samples,
+            format_distance(p.sample_range),
             p.verification_samples,
             format_distance(p.max_verify_range),
+        )
+
+        # Build a mode configuration with the effective samples/sample_range
+        # from the macro parameters so every probe sequence uses them.
+        effective_config = replace(
+            TouchModeConfiguration.from_config(self._config),
+            samples=p.samples,
+            sample_range=p.sample_range,
         )
 
         calibration_mode = CalibrationTouchMode(
             self._mcu,
             self._toolhead,
-            TouchModeConfiguration.from_config(self._config),
+            effective_config,
             threshold=p.threshold_start,
             speed=p.speed,
         )
 
-        screener = ThresholdScreener(calibration_mode, required_samples)
+        screener = ThresholdScreener(calibration_mode, p.samples)
         verifier = ThresholdVerifier(calibration_mode)
+
+        # Screening window: required samples + noisy samples tolerance
+        screening_samples = p.samples + self._config.touch.max_noisy_samples
 
         with force_home_z(self._toolhead):
             threshold = self._find_threshold(
@@ -312,16 +352,17 @@ class TouchCalibrateMacro(Macro):
                 verifier,
                 p.threshold_start,
                 p.threshold_max,
-                sample_range,
+                p.sample_range,
                 p.max_verify_range,
                 p.verification_samples,
+                screening_samples,
             )
 
         if threshold is None:
             self._log_calibration_failure(p.threshold_start, p.threshold_max)
             return
 
-        self._save_calibration_result(name, threshold, p.speed)
+        self._save_calibration_result(name, threshold, p.speed, p.samples, p.sample_range)
 
     def _move_to_calibration_position(self) -> None:
         """Move to the zero reference position for calibration."""
@@ -341,6 +382,7 @@ class TouchCalibrateMacro(Macro):
         sample_range: float,
         max_verify_range: float,
         verification_samples: int,
+        screening_samples: int,
     ) -> int | None:
         """
         Find the minimum threshold that produces consistent results.
@@ -351,7 +393,6 @@ class TouchCalibrateMacro(Macro):
         3. Accept if probe results are consistent
         """
         threshold = threshold_start
-        screening_samples = self._config.touch.samples + self._config.touch.max_noisy_samples
 
         while threshold <= threshold_max:
             # Phase 1: Quick screening
@@ -416,6 +457,8 @@ class TouchCalibrateMacro(Macro):
         name: str,
         threshold: int,
         speed: float,
+        samples: int,
+        sample_range: float,
     ) -> None:
         """Save the calibration result and log success."""
         logger.info(
@@ -423,7 +466,14 @@ class TouchCalibrateMacro(Macro):
             threshold,
             speed,
         )
-        model = TouchModelConfiguration(name=name, threshold=threshold, speed=speed, z_offset=DEFAULT_Z_OFFSET)
+        model = TouchModelConfiguration(
+            name=name,
+            threshold=threshold,
+            speed=speed,
+            z_offset=DEFAULT_Z_OFFSET,
+            samples=samples,
+            sample_range=sample_range,
+        )
         self._config.save_touch_model(model)
         self._probe.touch.load_model(name)
         logger.info(
@@ -540,13 +590,7 @@ class CalibrationTouchMode(TouchMode):
         """
         Perform one complete touch probe sequence.
 
-        Uses the shared run_probe_sequence to ensure parity with
+        Uses the shared _run_probe() to ensure parity with
         the runtime TouchMode._run_probe() logic.
         """
-        return run_probe_sequence(
-            self._perform_single_probe,
-            samples=self._config.samples,
-            max_samples=self._config.max_samples,
-            max_window=self._config.max_window,
-            sample_range=self._config.sample_range,
-        )
+        return self._run_probe()

--- a/src/cartographer/macros/touch/probe.py
+++ b/src/cartographer/macros/touch/probe.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING, final
 
 from typing_extensions import override
 
+from cartographer.interfaces.configuration import TouchConfig
 from cartographer.interfaces.printer import Macro, MacroParams, Position, Toolhead
-from cartographer.macros.fields import parse
+from cartographer.macros.fields import config_ref, param, parse
 
 if TYPE_CHECKING:
     from cartographer.probe.touch_mode import TouchMode
@@ -18,7 +19,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class TouchProbeMacroParams:
-    """Parameters for CARTOGRAPHER_TOUCH."""
+    """Parameters for CARTOGRAPHER_TOUCH_PROBE."""
+
+    max_samples: int = param(
+        "Per-call maximum number of touch attempts before giving up."
+        " Overrides the configured max_samples for this probe call only.",
+        default=config_ref(TouchConfig, "max_samples"),
+        min=1,
+    )
 
 
 @final
@@ -27,14 +35,15 @@ class TouchProbeMacro(Macro):
     last_trigger_position: float | None = None
     last_probe_position: Position | None = None
 
-    def __init__(self, probe: TouchMode, toolhead: Toolhead) -> None:
+    def __init__(self, probe: TouchMode, toolhead: Toolhead, *, max_samples: int) -> None:
         self._probe = probe
         self._toolhead = toolhead
+        self._max_samples = max_samples
 
     @override
     def run(self, params: MacroParams) -> None:
-        _ = parse(TouchProbeMacroParams, params)
-        trigger_pos = self._probe.perform_probe()
+        p = parse(TouchProbeMacroParams, params, max_samples=self._max_samples)
+        trigger_pos = self._probe.perform_probe(max_samples=p.max_samples)
         self.last_trigger_position = trigger_pos
         offset = self._probe.offset
         pos = self._toolhead.get_position()

--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -239,7 +239,7 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
             raise RuntimeError(msg)
 
         model = self.get_model()
-        effective_samples = model.samples if model.samples is not None else self._config.samples
+        effective_samples = model.samples
         effective_max = max_samples if max_samples is not None else self._config.max_samples
         if effective_max < effective_samples:
             msg = (
@@ -257,8 +257,8 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
 
     def _run_probe(self, max_samples: int | None = None) -> float:
         model = self.get_model()
-        samples = model.samples if model.samples is not None else self._config.samples
-        sample_range = model.sample_range if model.sample_range is not None else self._config.sample_range
+        samples = model.samples
+        sample_range = model.sample_range
         effective_max = max_samples if max_samples is not None else self._config.max_samples
         max_window = samples + self._config.max_noisy_samples
         return run_probe_sequence(

--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -39,7 +39,7 @@ _TOUCH_FLOOR_TOLERANCE = 0.001
 class TouchModeConfiguration:
     samples: int
     max_samples: int
-    max_window: int
+    max_noisy_samples: int
 
     x_offset: float
     y_offset: float
@@ -53,11 +53,11 @@ class TouchModeConfiguration:
     sample_range: float
 
     @staticmethod
-    def from_config(config: Configuration):
+    def from_config(config: Configuration) -> TouchModeConfiguration:
         return TouchModeConfiguration(
             samples=config.touch.samples,
             max_samples=config.touch.max_samples,
-            max_window=config.touch.samples + config.touch.max_noisy_samples,
+            max_noisy_samples=config.touch.max_noisy_samples,
             models=config.touch.models,
             x_offset=config.general.x_offset,
             y_offset=config.general.y_offset,
@@ -233,25 +233,40 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
         }
 
     @override
-    def perform_probe(self) -> float:
+    def perform_probe(self, max_samples: int | None = None) -> float:
         if not self._toolhead.is_homed("z"):
             msg = "Z axis must be homed before probing"
+            raise RuntimeError(msg)
+
+        model = self.get_model()
+        effective_samples = model.samples if model.samples is not None else self._config.samples
+        effective_max = max_samples if max_samples is not None else self._config.max_samples
+        if effective_max < effective_samples:
+            msg = (
+                f"max_samples ({effective_max}) must be >= the effective samples ({effective_samples}) "
+                f"required by the current model"
+            )
             raise RuntimeError(msg)
 
         if self._toolhead.get_position().z < self._config.retract_distance:
             self._toolhead.move(z=self._config.retract_distance, speed=self._config.lift_speed)
         self._toolhead.wait_moves()
 
-        self.last_z_result = self._run_probe()
+        self.last_z_result = self._run_probe(max_samples=max_samples)
         return self.last_z_result
 
-    def _run_probe(self) -> float:
+    def _run_probe(self, max_samples: int | None = None) -> float:
+        model = self.get_model()
+        samples = model.samples if model.samples is not None else self._config.samples
+        sample_range = model.sample_range if model.sample_range is not None else self._config.sample_range
+        effective_max = max_samples if max_samples is not None else self._config.max_samples
+        max_window = samples + self._config.max_noisy_samples
         return run_probe_sequence(
             self._perform_single_probe,
-            samples=self._config.samples,
-            max_samples=self._config.max_samples,
-            max_window=self._config.max_window,
-            sample_range=self._config.sample_range,
+            samples=samples,
+            max_samples=effective_max,
+            max_window=max_window,
+            sample_range=sample_range,
         )
 
     def _perform_single_probe(self) -> float:

--- a/src/cartographer/probe/touch_model.py
+++ b/src/cartographer/probe/touch_model.py
@@ -30,11 +30,11 @@ class TouchModel:
         return self.config.threshold
 
     @property
-    def samples(self) -> int | None:
+    def samples(self) -> int:
         return self.config.samples
 
     @property
-    def sample_range(self) -> float | None:
+    def sample_range(self) -> float:
         return self.config.sample_range
 
 

--- a/src/cartographer/probe/touch_model.py
+++ b/src/cartographer/probe/touch_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import final
 
 from typing_extensions import override
@@ -26,6 +28,14 @@ class TouchModel:
     @property
     def threshold(self) -> int:
         return self.config.threshold
+
+    @property
+    def samples(self) -> int | None:
+        return self.config.samples
+
+    @property
+    def sample_range(self) -> float | None:
+        return self.config.sample_range
 
 
 class TouchModelSelectorMixin(ModelSelectorMixin[TouchModel, TouchModelConfiguration]):

--- a/tests/config/test_model_validator.py
+++ b/tests/config/test_model_validator.py
@@ -103,6 +103,8 @@ def test_removes_touch_model_with_mcu_mismatch(config: MockConfiguration):
         threshold=1000,
         speed=3.0,
         z_offset=0.0,
+        samples=3,
+        sample_range=0.010,
         version_info=ModelVersionInfo(mcu_version="old_mcu", software_version="1.2.0"),
     )
 
@@ -186,6 +188,8 @@ def test_validates_multiple_models(config: MockConfiguration):
         threshold=1000,
         speed=3.0,
         z_offset=0.0,
+        samples=3,
+        sample_range=0.010,
         version_info=ModelVersionInfo(mcu_version="abc123", software_version="1.2.0"),
     )
     config.touch.models["bad_touch"] = TouchModelConfiguration(
@@ -193,6 +197,8 @@ def test_validates_multiple_models(config: MockConfiguration):
         threshold=1000,
         speed=3.0,
         z_offset=0.0,
+        samples=3,
+        sample_range=0.010,
         version_info=ModelVersionInfo(mcu_version="abc123", software_version="0.5.0"),
     )
 

--- a/tests/config/test_touch_model_loader.py
+++ b/tests/config/test_touch_model_loader.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from cartographer.adapters.klipper.configuration import _parse_touch_model_with_defaults
+from cartographer.adapters.klipper.configuration import parse_touch_model_with_defaults
 from cartographer.config.fields import parse
-from cartographer.interfaces.configuration import TouchConfig, TouchModelConfiguration
+from cartographer.interfaces.configuration import TouchConfig
 
 if TYPE_CHECKING:
     from configfile import ConfigWrapper
@@ -87,11 +87,11 @@ def test_missing_fields_inherit_non_default_globals() -> None:
     """Model section without samples/sample_range picks up non-default global values.
 
     Legacy model sections written before these keys existed must end up with
-    concrete concrete values equal to the current global config, not the
+    concrete values equal to the current global config, not the
     hard-coded option defaults.
     """
     global_touch = _global_touch({"samples": 7, "sample_range": 0.008})
-    result = _parse_touch_model_with_defaults(
+    result = parse_touch_model_with_defaults(
         _model_section("legacy"),
         global_samples=global_touch.samples,
         global_sample_range=global_touch.sample_range,
@@ -103,23 +103,10 @@ def test_missing_fields_inherit_non_default_globals() -> None:
 def test_explicit_model_fields_override_globals() -> None:
     """Explicit samples/sample_range in a model section win over the global config."""
     global_touch = _global_touch({"samples": 7, "sample_range": 0.008})
-    result = _parse_touch_model_with_defaults(
+    result = parse_touch_model_with_defaults(
         _model_section("override", {"samples": 5, "sample_range": 0.012}),
         global_samples=global_touch.samples,
         global_sample_range=global_touch.sample_range,
     )
     assert result.samples == 5
     assert abs(result.sample_range - 0.012) < 1e-9
-
-
-def test_parsed_model_has_concrete_types() -> None:
-    """Every model returned by the loader has concrete int/float fields, never None."""
-    global_touch = _global_touch()
-    result = _parse_touch_model_with_defaults(
-        _model_section("concrete"),
-        global_samples=global_touch.samples,
-        global_sample_range=global_touch.sample_range,
-    )
-    assert isinstance(result, TouchModelConfiguration)
-    assert isinstance(result.samples, int)
-    assert isinstance(result.sample_range, float)

--- a/tests/config/test_touch_model_loader.py
+++ b/tests/config/test_touch_model_loader.py
@@ -1,0 +1,125 @@
+"""Focused tests: touch model loader inherits non-default global sampling config."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from cartographer.adapters.klipper.configuration import _parse_touch_model_with_defaults
+from cartographer.config.fields import parse
+from cartographer.interfaces.configuration import TouchConfig, TouchModelConfiguration
+
+if TYPE_CHECKING:
+    from configfile import ConfigWrapper
+
+
+class _FakeSection:
+    """Minimal structural stub for the Klipper ConfigWrapper section interface."""
+
+    def __init__(self, name: str, values: dict[str, object]) -> None:
+        self._name = name
+        self._values = values
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get(self, key: str, default: object = None) -> object:
+        return self._values.get(key, default)
+
+    def getint(self, key: str, default: object = None, minval: int | None = None, maxval: int | None = None) -> object:
+        val = self._values.get(key, default)
+        return int(val) if val is not None else default
+
+    def getfloat(
+        self,
+        key: str,
+        default: object = None,
+        minval: float | None = None,
+        maxval: float | None = None,
+        note_valid: bool = True,
+    ) -> object:
+        val = self._values.get(key, default)
+        return float(val) if val is not None else default
+
+    def getboolean(self, key: str, default: object = None) -> object:
+        return self._values.get(key, default)
+
+    def getfloatlist(self, key: str, count: int | None = None, default: object = None) -> object:
+        return self._values.get(key, default)
+
+    def getintlist(self, key: str, count: int | None = None, default: object = None) -> object:
+        return self._values.get(key, default)
+
+    def getchoice(self, key: str, choices: dict[str, str], default: object = None) -> object:
+        val = self._values.get(key, default)
+        return str(val) if val is not None else default
+
+
+def _global_touch(overrides: dict[str, object] | None = None) -> TouchConfig:
+    """Parse a TouchConfig from a fake section with optional overrides."""
+    base: dict[str, object] = {
+        "samples": 3,
+        "max_samples": 10,
+        "max_noisy_samples": 2,
+        "UNSAFE_max_touch_temperature": 150,
+        "EXPERIMENTAL_home_random_radius": 0.0,
+        "retract_distance": 2.0,
+        "sample_range": 0.010,
+    }
+    if overrides:
+        base.update(overrides)
+    section = cast("ConfigWrapper", _FakeSection("cartographer touch", base))
+    return parse(TouchConfig, section, models={})
+
+
+def _model_section(name: str, overrides: dict[str, object] | None = None) -> ConfigWrapper:
+    """Build a fake touch_model section."""
+    base: dict[str, object] = {
+        "speed": 3.0,
+        "z_offset": -0.05,
+        "threshold": 1000,
+    }
+    if overrides:
+        base.update(overrides)
+    return cast("ConfigWrapper", _FakeSection(f"cartographer touch_model {name}", base))
+
+
+def test_missing_fields_inherit_non_default_globals() -> None:
+    """Model section without samples/sample_range picks up non-default global values.
+
+    Legacy model sections written before these keys existed must end up with
+    concrete concrete values equal to the current global config, not the
+    hard-coded option defaults.
+    """
+    global_touch = _global_touch({"samples": 7, "sample_range": 0.008})
+    result = _parse_touch_model_with_defaults(
+        _model_section("legacy"),
+        global_samples=global_touch.samples,
+        global_sample_range=global_touch.sample_range,
+    )
+    assert result.samples == 7
+    assert abs(result.sample_range - 0.008) < 1e-9
+
+
+def test_explicit_model_fields_override_globals() -> None:
+    """Explicit samples/sample_range in a model section win over the global config."""
+    global_touch = _global_touch({"samples": 7, "sample_range": 0.008})
+    result = _parse_touch_model_with_defaults(
+        _model_section("override", {"samples": 5, "sample_range": 0.012}),
+        global_samples=global_touch.samples,
+        global_sample_range=global_touch.sample_range,
+    )
+    assert result.samples == 5
+    assert abs(result.sample_range - 0.012) < 1e-9
+
+
+def test_parsed_model_has_concrete_types() -> None:
+    """Every model returned by the loader has concrete int/float fields, never None."""
+    global_touch = _global_touch()
+    result = _parse_touch_model_with_defaults(
+        _model_section("concrete"),
+        global_samples=global_touch.samples,
+        global_sample_range=global_touch.sample_range,
+    )
+    assert isinstance(result, TouchModelConfiguration)
+    assert isinstance(result.samples, int)
+    assert isinstance(result.sample_range, float)

--- a/tests/config/test_touch_model_loader.py
+++ b/tests/config/test_touch_model_loader.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
 class _FakeSection:
     """Minimal structural stub for the Klipper ConfigWrapper section interface."""
 
+    _name: str
+    _values: dict[str, object]
+
     def __init__(self, name: str, values: dict[str, object]) -> None:
         self._name = name
         self._values = values
@@ -26,8 +29,9 @@ class _FakeSection:
         return self._values.get(key, default)
 
     def getint(self, key: str, default: object = None, minval: int | None = None, maxval: int | None = None) -> object:
+        _ = (minval, maxval)
         val = self._values.get(key, default)
-        return int(val) if val is not None else default
+        return int(val) if isinstance(val, (int, float, str)) else default
 
     def getfloat(
         self,
@@ -37,19 +41,23 @@ class _FakeSection:
         maxval: float | None = None,
         note_valid: bool = True,
     ) -> object:
+        _ = (minval, maxval, note_valid)
         val = self._values.get(key, default)
-        return float(val) if val is not None else default
+        return float(val) if isinstance(val, (int, float, str)) else default
 
     def getboolean(self, key: str, default: object = None) -> object:
         return self._values.get(key, default)
 
     def getfloatlist(self, key: str, count: int | None = None, default: object = None) -> object:
+        _ = count
         return self._values.get(key, default)
 
     def getintlist(self, key: str, count: int | None = None, default: object = None) -> object:
+        _ = count
         return self._values.get(key, default)
 
     def getchoice(self, key: str, choices: dict[str, str], default: object = None) -> object:
+        _ = choices
         val = self._values.get(key, default)
         return str(val) if val is not None else default
 
@@ -67,7 +75,7 @@ def _global_touch(overrides: dict[str, object] | None = None) -> TouchConfig:
     }
     if overrides:
         base.update(overrides)
-    section = cast("ConfigWrapper", _FakeSection("cartographer touch", base))
+    section = cast("ConfigWrapper", cast("object", _FakeSection("cartographer touch", base)))
     return parse(TouchConfig, section, models={})
 
 
@@ -80,7 +88,7 @@ def _model_section(name: str, overrides: dict[str, object] | None = None) -> Con
     }
     if overrides:
         base.update(overrides)
-    return cast("ConfigWrapper", _FakeSection(f"cartographer touch_model {name}", base))
+    return cast("ConfigWrapper", cast("object", _FakeSection(f"cartographer touch_model {name}", base)))
 
 
 def test_missing_fields_inherit_non_default_globals() -> None:

--- a/tests/config/test_touch_model_persistence.py
+++ b/tests/config/test_touch_model_persistence.py
@@ -3,39 +3,15 @@ from __future__ import annotations
 from cartographer.interfaces.configuration import TouchModelConfiguration
 
 
-class TestTouchModelDefaults:
-    def test_legacy_model_samples_default_is_none(self) -> None:
-        """TouchModelConfiguration.samples defaults to None (legacy models have no override)."""
-        cfg = TouchModelConfiguration(name="legacy", speed=3.0, z_offset=0.0)
-        assert cfg.samples is None
+class TestTouchModelFields:
+    def test_model_has_concrete_types(self) -> None:
+        """TouchModelConfiguration fields are concrete (not Optional) int/float."""
+        cfg = TouchModelConfiguration(name="model", speed=3.0, z_offset=0.0, samples=3, sample_range=0.010)
+        assert isinstance(cfg.samples, int)
+        assert isinstance(cfg.sample_range, float)
 
-    def test_legacy_model_sample_range_default_is_none(self) -> None:
-        """TouchModelConfiguration.sample_range defaults to None (legacy models have no override)."""
-        cfg = TouchModelConfiguration(name="legacy", speed=3.0, z_offset=0.0)
-        assert cfg.sample_range is None
-
-
-class TestTouchModelPopulatedFields:
-    def test_samples_stored_when_set(self) -> None:
-        """A configured samples value is stored and retrievable."""
-        cfg = TouchModelConfiguration(name="custom", speed=3.0, z_offset=0.0, samples=5)
-        assert cfg.samples == 5
-
-    def test_sample_range_stored_when_set(self) -> None:
-        """A configured sample_range value is stored and retrievable."""
-        cfg = TouchModelConfiguration(name="ranged", speed=3.0, z_offset=0.0, sample_range=0.008)
-        assert cfg.sample_range is not None
-        assert abs(cfg.sample_range - 0.008) < 1e-9
-
-    def test_both_fields_stored_independently(self) -> None:
-        """Both samples and sample_range can be set and retrieved independently."""
-        cfg = TouchModelConfiguration(name="both", speed=3.0, z_offset=0.0, samples=7, sample_range=0.012)
+    def test_non_default_values_stored(self) -> None:
+        """Non-default samples/sample_range values are preserved as-is."""
+        cfg = TouchModelConfiguration(name="custom", speed=3.0, z_offset=0.0, samples=7, sample_range=0.008)
         assert cfg.samples == 7
-        assert cfg.sample_range is not None
-        assert abs(cfg.sample_range - 0.012) < 1e-9
-
-    def test_samples_none_not_overwritten_by_default(self) -> None:
-        """Round-trip: a model created without samples keeps samples=None."""
-        original = TouchModelConfiguration(name="rt_legacy", speed=3.0, z_offset=0.0)
-        assert original.samples is None
-        assert original.sample_range is None
+        assert abs(cfg.sample_range - 0.008) < 1e-9

--- a/tests/config/test_touch_model_persistence.py
+++ b/tests/config/test_touch_model_persistence.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from cartographer.interfaces.configuration import TouchModelConfiguration
+
+
+class TestTouchModelDefaults:
+    def test_legacy_model_samples_default_is_none(self) -> None:
+        """TouchModelConfiguration.samples defaults to None (legacy models have no override)."""
+        cfg = TouchModelConfiguration(name="legacy", speed=3.0, z_offset=0.0)
+        assert cfg.samples is None
+
+    def test_legacy_model_sample_range_default_is_none(self) -> None:
+        """TouchModelConfiguration.sample_range defaults to None (legacy models have no override)."""
+        cfg = TouchModelConfiguration(name="legacy", speed=3.0, z_offset=0.0)
+        assert cfg.sample_range is None
+
+
+class TestTouchModelPopulatedFields:
+    def test_samples_stored_when_set(self) -> None:
+        """A configured samples value is stored and retrievable."""
+        cfg = TouchModelConfiguration(name="custom", speed=3.0, z_offset=0.0, samples=5)
+        assert cfg.samples == 5
+
+    def test_sample_range_stored_when_set(self) -> None:
+        """A configured sample_range value is stored and retrievable."""
+        cfg = TouchModelConfiguration(name="ranged", speed=3.0, z_offset=0.0, sample_range=0.008)
+        assert cfg.sample_range is not None
+        assert abs(cfg.sample_range - 0.008) < 1e-9
+
+    def test_both_fields_stored_independently(self) -> None:
+        """Both samples and sample_range can be set and retrieved independently."""
+        cfg = TouchModelConfiguration(name="both", speed=3.0, z_offset=0.0, samples=7, sample_range=0.012)
+        assert cfg.samples == 7
+        assert cfg.sample_range is not None
+        assert abs(cfg.sample_range - 0.012) < 1e-9
+
+    def test_samples_none_not_overwritten_by_default(self) -> None:
+        """Round-trip: a model created without samples keeps samples=None."""
+        original = TouchModelConfiguration(name="rt_legacy", speed=3.0, z_offset=0.0)
+        assert original.samples is None
+        assert original.sample_range is None

--- a/tests/macros/test_fields.py
+++ b/tests/macros/test_fields.py
@@ -1,0 +1,69 @@
+"""Integration tests: ComputedDefault metadata rendered through generate_docs()."""
+
+from __future__ import annotations
+
+import pytest
+
+from cartographer.macros.docs import generate_docs
+from cartographer.macros.fields import ComputedDefault, get_all_params
+from cartographer.macros.touch.calibrate import TouchCalibrateParams
+
+_EXPECTED_COMPUTED_TEXT = "computed: 2 \u00d7 effective SAMPLE_RANGE"
+_MACRO_HEADER = "## CARTOGRAPHER_TOUCH_CALIBRATE"
+
+
+def _touch_calibrate_section() -> str:
+    """Extract the CARTOGRAPHER_TOUCH_CALIBRATE section from generated docs."""
+    docs = generate_docs()
+    start = docs.find(_MACRO_HEADER)
+    assert start != -1, f"{_MACRO_HEADER!r} section not found in generated docs"
+    # Find the next ## heading after this section
+    next_section = docs.find("\n## ", start + len(_MACRO_HEADER))
+    return docs[start:] if next_section == -1 else docs[start:next_section]
+
+
+@pytest.fixture(scope="module")
+def calibrate_section() -> str:
+    return _touch_calibrate_section()
+
+
+class TestMaxVerifyRangeDocs:
+    """MAX_VERIFY_RANGE must render as computed, optional, and absent from example."""
+
+    def test_docs_show_computed_default(self, calibrate_section: str) -> None:
+        """Generated docs must label MAX_VERIFY_RANGE with its computed formula."""
+        assert _EXPECTED_COMPUTED_TEXT in calibrate_section, (
+            f"Expected {_EXPECTED_COMPUTED_TEXT!r} in CARTOGRAPHER_TOUCH_CALIBRATE section"
+        )
+
+    def test_docs_do_not_mark_required(self, calibrate_section: str) -> None:
+        """MAX_VERIFY_RANGE must not appear as a required parameter."""
+        # The required pattern is "MAX_VERIFY_RANGE (float, required)"
+        assert "MAX_VERIFY_RANGE (float, required)" not in calibrate_section
+
+    def test_example_omits_max_verify_range(self, calibrate_section: str) -> None:
+        """Example command line must not contain a MAX_VERIFY_RANGE placeholder."""
+        # Locate the Example block inside the section
+        example_start = calibrate_section.find("**Example:**")
+        assert example_start != -1, "Example block not found in CARTOGRAPHER_TOUCH_CALIBRATE section"
+        example_block = calibrate_section[example_start:]
+        assert "MAX_VERIFY_RANGE" not in example_block
+
+    def test_max_verify_range_metadata_is_computed_default(self) -> None:
+        """Direct metadata check: MAX_VERIFY_RANGE must carry a ComputedDefault sentinel."""
+        params = get_all_params(TouchCalibrateParams)
+        field = next((p for p in params if p.name == "MAX_VERIFY_RANGE"), None)
+        assert field is not None, "MAX_VERIFY_RANGE not found in TouchCalibrateParams"
+        assert isinstance(field.default, ComputedDefault), (
+            f"Expected ComputedDefault, got {type(field.default).__name__}"
+        )
+        assert "2 × effective SAMPLE_RANGE" in field.default.display
+
+    def test_docs_show_valid_interval(self, calibrate_section: str) -> None:
+        """Generated docs must state the valid interval relative to SAMPLE_RANGE."""
+        assert "at least effective SAMPLE_RANGE" in calibrate_section
+        assert "4 \u00d7 effective SAMPLE_RANGE" in calibrate_section
+
+    def test_docs_show_samples_max_samples_constraint(self, calibrate_section: str) -> None:
+        """Generated docs must state SAMPLES cannot exceed max_samples."""
+        assert "Cannot exceed configured [cartographer touch] max_samples" in calibrate_section

--- a/tests/macros/test_touch.py
+++ b/tests/macros/test_touch.py
@@ -9,6 +9,7 @@ from typing_extensions import TypeAlias
 from cartographer.interfaces.printer import MacroParams, Position, Toolhead
 from cartographer.macros.touch import TouchAccuracyMacro, TouchHomeMacro, TouchProbeMacro
 from cartographer.probe.touch_mode import TouchMode, TouchModeConfiguration
+from tests.mocks.params import MockParams
 
 if TYPE_CHECKING:
     from pytest import LogCaptureFixture
@@ -39,13 +40,45 @@ def test_touch_macro_output(
     params: MacroParams,
     toolhead: Toolhead,
 ):
-    macro = TouchProbeMacro(probe, toolhead)
+    macro = TouchProbeMacro(probe, toolhead, max_samples=10)
     probe.perform_probe = mocker.Mock(return_value=5.0)
 
     with caplog.at_level(logging.INFO):
         macro.run(params)
 
     assert "Result: at 10.000,10.000 estimate contact at z=5.000000" in caplog.messages
+
+
+def test_touch_probe_macro_omitted_max_samples_uses_configured_default(
+    mocker: MockerFixture,
+    probe: Probe,
+    params: MacroParams,
+    toolhead: Toolhead,
+):
+    """When MAX_SAMPLES is not supplied, the configured default is passed to perform_probe."""
+    macro = TouchProbeMacro(probe, toolhead, max_samples=7)
+    probe.perform_probe = mocker.Mock(return_value=0.5)
+
+    macro.run(params)
+
+    probe.perform_probe.assert_called_once_with(max_samples=7)
+
+
+def test_touch_probe_macro_explicit_max_samples_overrides_configured_default(
+    mocker: MockerFixture,
+    probe: Probe,
+    toolhead: Toolhead,
+):
+    """When MAX_SAMPLES is supplied, it overrides the configured default."""
+    explicit_params = MockParams()
+    explicit_params.params["MAX_SAMPLES"] = "20"
+
+    macro = TouchProbeMacro(probe, toolhead, max_samples=7)
+    probe.perform_probe = mocker.Mock(return_value=0.5)
+
+    macro.run(explicit_params)
+
+    probe.perform_probe.assert_called_once_with(max_samples=20)
 
 
 def test_touch_accuracy_macro_output(
@@ -62,7 +95,8 @@ def test_touch_accuracy_macro_output(
     i = -1
     measurements: list[float] = [50 + i * 10 for i in range(10)]
 
-    def mock_probe(**_) -> float:
+    def mock_probe(max_samples: int | None = None) -> float:
+        _ = max_samples
         nonlocal i
         i += 1
         return measurements[i]
@@ -95,7 +129,8 @@ def test_touch_accuracy_macro_sample_count(
     i = -1
     measurements: list[float] = [50 + i * 10 for i in range(10)]
 
-    def mock_probe(**_) -> float:
+    def mock_probe(max_samples: int | None = None) -> float:
+        _ = max_samples
         nonlocal i
         i += 1
         return measurements[i]

--- a/tests/macros/test_touch_calibrate.py
+++ b/tests/macros/test_touch_calibrate.py
@@ -519,7 +519,6 @@ class TestTouchCalibrateParams:
 
         saved = config.touch.models["default"]
         assert saved.samples == 7
-        assert saved.sample_range is not None
         assert abs(saved.sample_range - 0.008) < 1e-9
 
     def test_calibration_execution_uses_effective_samples(self, mocker: MockerFixture):

--- a/tests/macros/test_touch_calibrate.py
+++ b/tests/macros/test_touch_calibrate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from typing_extensions import final
 
@@ -9,13 +11,18 @@ from cartographer.macros.touch.calibrate import (
     ScreeningResult,
     ThresholdScreener,
     ThresholdVerifier,
+    TouchCalibrateMacro,
     TouchCalibrateParams,
     VerificationResult,
     calculate_step,
     format_distance,
 )
 from cartographer.probe.touch_mode import TouchError
+from tests.mocks.config import MockConfiguration
 from tests.mocks.params import MockParams
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 # --- Fake probe for testing ---
 
@@ -39,7 +46,7 @@ class FakeCalibrationProbe:
         self._probe_results = list(probe_results or [])
         self.thresholds_set: list[int] = []
 
-    def collect_samples(self, threshold: int, sample_count: int) -> tuple[float, ...]:  # noqa: ARG002
+    def collect_samples(self, threshold: int, sample_count: int) -> tuple[float, ...]:
         _ = threshold, sample_count
         result = self._samples_results.pop(0)
         if isinstance(result, ProbeTriggerError):
@@ -278,7 +285,7 @@ class TestThresholdVerifier:
         result = verifier.verify(threshold=1000, max_verify_range=0.020, sample_count=3)
 
         assert result is not None
-        assert result.median_range == pytest.approx(0.010)  # pyright: ignore[reportUnknownMemberType]
+        assert abs(result.median_range - 0.010) < 1e-9
         assert result.probe_medians == [1.000, 1.010, 1.005]
 
 
@@ -333,6 +340,208 @@ class TestTouchCalibrateParams:
         p = parse(
             TouchCalibrateParams,
             mock,
+            samples=3,
+            sample_range=0.010,
             max_verify_range=0.020,
         )
         assert p.speed == 1.5
+
+    def test_samples_defaults_from_config(self):
+        """SAMPLES defaults to the value supplied via config defaults."""
+        mock = MockParams()
+        p = parse(
+            TouchCalibrateParams,
+            mock,
+            samples=5,
+            sample_range=0.010,
+            max_verify_range=0.020,
+        )
+        assert p.samples == 5
+
+    def test_samples_explicit_override(self):
+        """Explicit SAMPLES= overrides the config default."""
+        mock = MockParams()
+        mock.params["SAMPLES"] = "7"
+        p = parse(
+            TouchCalibrateParams,
+            mock,
+            samples=5,
+            sample_range=0.010,
+            max_verify_range=0.020,
+        )
+        assert p.samples == 7
+
+    def test_sample_range_defaults_from_config(self):
+        """SAMPLE_RANGE defaults to the value supplied via config defaults."""
+        mock = MockParams()
+        p = parse(
+            TouchCalibrateParams,
+            mock,
+            samples=5,
+            sample_range=0.008,
+            max_verify_range=0.016,
+        )
+        assert abs(p.sample_range - 0.008) < 1e-9
+
+    def test_sample_range_explicit_override(self):
+        """Explicit SAMPLE_RANGE= overrides the config default."""
+        mock = MockParams()
+        mock.params["SAMPLE_RANGE"] = "0.005"
+        p = parse(
+            TouchCalibrateParams,
+            mock,
+            samples=5,
+            sample_range=0.010,
+            max_verify_range=0.020,
+        )
+        assert abs(p.sample_range - 0.005) < 1e-9
+
+    def test_max_verify_range_uses_effective_sample_range_default(self, mocker: MockerFixture):
+        """MAX_VERIFY_RANGE defaults to 2× effective SAMPLE_RANGE."""
+        config = MockConfiguration()
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        # Patch _find_threshold to return a threshold immediately so run() completes.
+        find_threshold_spy = mocker.patch.object(macro, "_find_threshold", return_value=1500)
+        _ = mocker.patch.object(macro, "_move_to_calibration_position")
+        toolhead.is_homed.return_value = True
+
+        params = MockParams()
+        # Do not set MAX_VERIFY_RANGE; it should default to 2× config.sample_range (0.010)
+        macro.run(params)
+
+        # Prove _find_threshold was called with max_verify_range = 2× effective sample_range
+        call_args = find_threshold_spy.call_args
+        args = call_args.args
+        # args[4] = sample_range, args[5] = max_verify_range
+        assert abs(args[4] - config.touch.sample_range) < 1e-9
+        assert abs(args[5] - args[4] * 2) < 1e-9
+
+    def test_max_verify_range_scaled_by_explicit_sample_range(self, mocker: MockerFixture):
+        """MAX_VERIFY_RANGE defaults to 2× the explicit SAMPLE_RANGE parameter."""
+        config = MockConfiguration()
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        find_threshold_spy = mocker.patch.object(macro, "_find_threshold", return_value=1500)
+        _ = mocker.patch.object(macro, "_move_to_calibration_position")
+        toolhead.is_homed.return_value = True
+
+        params = MockParams()
+        params.params["SAMPLE_RANGE"] = "0.005"
+        # MAX_VERIFY_RANGE not supplied — should default to 2× 0.005 = 0.010
+        macro.run(params)
+
+        # Prove _find_threshold was called with max_verify_range = 2× explicit SAMPLE_RANGE
+        call_args = find_threshold_spy.call_args
+        args = call_args.args
+        # args[4] = sample_range, args[5] = max_verify_range
+        assert abs(args[4] - 0.005) < 1e-9
+        assert abs(args[5] - args[4] * 2) < 1e-9
+
+    def test_max_verify_range_below_sample_range_raises(self, mocker: MockerFixture):
+        """MAX_VERIFY_RANGE below SAMPLE_RANGE must raise RuntimeError."""
+        config = MockConfiguration()
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        params = MockParams()
+        # sample_range = 0.010 (config default); set max_verify_range below it
+        params.params["MAX_VERIFY_RANGE"] = "0.008"
+
+        with pytest.raises(RuntimeError, match="MAX_VERIFY_RANGE"):
+            macro.run(params)
+
+    def test_max_verify_range_above_4x_sample_range_raises(self, mocker: MockerFixture):
+        """MAX_VERIFY_RANGE above 4× SAMPLE_RANGE must raise RuntimeError."""
+        config = MockConfiguration()
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        params = MockParams()
+        # sample_range = 0.010 (config default); 4× = 0.040; set above it
+        params.params["MAX_VERIFY_RANGE"] = "0.050"
+
+        with pytest.raises(RuntimeError, match="MAX_VERIFY_RANGE"):
+            macro.run(params)
+
+    def test_samples_exceeding_max_samples_raises_before_movement(self, mocker: MockerFixture):
+        """SAMPLES > config.touch.max_samples must raise RuntimeError before any movement."""
+        config = MockConfiguration()  # default: max_samples=10
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        # Patch _move_to_calibration_position to assert it is never called.
+        move_spy = mocker.patch.object(macro, "_move_to_calibration_position")
+
+        params = MockParams()
+        params.params["SAMPLES"] = "11"  # exceeds max_samples=10
+
+        with pytest.raises(RuntimeError, match="SAMPLES"):
+            macro.run(params)
+
+        move_spy.assert_not_called()
+        toolhead.move.assert_not_called()
+
+    def test_saved_model_stores_samples_and_sample_range(self, mocker: MockerFixture):
+        """Calibration result must persist effective samples and sample_range."""
+        config = MockConfiguration()
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        _ = mocker.patch.object(macro, "_find_threshold", return_value=2000)
+        _ = mocker.patch.object(macro, "_move_to_calibration_position")
+        toolhead.is_homed.return_value = True
+
+        params = MockParams()
+        params.params["SAMPLES"] = "7"
+        params.params["SAMPLE_RANGE"] = "0.008"
+        macro.run(params)
+
+        saved = config.touch.models["default"]
+        assert saved.samples == 7
+        assert saved.sample_range is not None
+        assert abs(saved.sample_range - 0.008) < 1e-9
+
+    def test_calibration_execution_uses_effective_samples(self, mocker: MockerFixture):
+        """The effective SAMPLES value drives screening_samples passed to _find_threshold."""
+        config = MockConfiguration()  # default: samples=5, max_noisy_samples=2
+        probe = mocker.Mock()
+        mcu = mocker.Mock()
+        toolhead = mocker.Mock()
+        task_executor = mocker.Mock()
+        macro = TouchCalibrateMacro(probe, mcu, toolhead, config, task_executor)
+
+        find_threshold_spy = mocker.patch.object(macro, "_find_threshold", return_value=1500)
+        _ = mocker.patch.object(macro, "_move_to_calibration_position")
+        toolhead.is_homed.return_value = True
+
+        params = MockParams()
+        params.params["SAMPLES"] = "4"  # override config default of 5
+        macro.run(params)
+
+        # _find_threshold receives screening_samples = SAMPLES + max_noisy_samples = 4 + 2 = 6
+        call_args = find_threshold_spy.call_args
+        # positional args: screener, verifier, start, max, sample_range,
+        # max_verify, verify_samples, screening_samples
+        args = call_args.args
+        assert args[7] == 6  # screening_samples at position index 7

--- a/tests/macros/test_z_offset_macros.py
+++ b/tests/macros/test_z_offset_macros.py
@@ -58,6 +58,8 @@ def calibrated_touch(touch: TouchMode, config: Configuration, toolhead: Toolhead
         threshold=1000,
         speed=3,
         z_offset=0.0,
+        samples=5,
+        sample_range=0.010,
     )
     touch.load_model("default")
     toolhead.get_axis_limits = mocker.Mock(return_value=(-5, 100))

--- a/tests/probes/test_touch_boundaries.py
+++ b/tests/probes/test_touch_boundaries.py
@@ -39,7 +39,7 @@ def make_config(
     return TouchModeConfiguration(
         samples=1,
         max_samples=1,
-        max_window=1,
+        max_noisy_samples=0,
         mesh_min=mesh_min,
         mesh_max=mesh_max,
         max_touch_temperature=150,

--- a/tests/probes/test_touch_probe.py
+++ b/tests/probes/test_touch_probe.py
@@ -21,6 +21,8 @@ def configure_probe(probe: Probe, config: Configuration) -> None:
             speed=3,
             threshold=1000,
             z_offset=0,
+            samples=5,
+            sample_range=0.010,
         )
     )
     probe.touch.load_model("test_touch")
@@ -42,6 +44,8 @@ def test_probe_includes_z_offset(
             speed=3,
             threshold=1000,
             z_offset=-0.5,
+            samples=5,
+            sample_range=0.010,
         )
     )
     probe.touch.load_model("test_touch")

--- a/tests/probes/test_touch_probe.py
+++ b/tests/probes/test_touch_probe.py
@@ -179,3 +179,44 @@ def test_probe_outside_bounds(mocker: MockerFixture, toolhead: Toolhead, probe: 
 
     with pytest.raises(RuntimeError, match="outside .* boundaries"):
         _ = probe.touch.home_start(0)
+
+
+def test_increased_budget_permits_longer_sequence(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
+    """An explicit max_samples override allows convergence that the config budget would exhaust.
+
+    With samples=5, max_noisy_samples=2 (window=7), and sample_range=0.010:
+    - 10 diverging values [1.0..1.9] prevent convergence within max_samples=10.
+    - Adding 5 more identical values (0.5) brings a clean 5-sample window at attempt 15,
+      which succeeds when the budget is raised to 15.
+    """
+    diverging = [round(1.0 + i * 0.1, 1) for i in range(10)]
+    converging = [0.5] * 5
+    side_effects = diverging + converging
+
+    toolhead.z_probing_move = mocker.Mock(side_effect=side_effects)
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 5))
+
+    # Default budget (max_samples=10) exhausts before convergence.
+    with pytest.raises(RuntimeError, match="Unable to find"):
+        _ = probe.touch.perform_probe()
+
+    # Reset the mock for the second run.
+    toolhead.z_probing_move = mocker.Mock(side_effect=side_effects)
+
+    # Raising the budget to 15 reaches the clean 5-sample window and succeeds.
+    result = probe.touch.perform_probe(max_samples=15)
+    assert result == 0.5
+
+
+def test_impossible_budget_fails_before_z_probing_move(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
+    """max_samples < effective_samples raises RuntimeError before any probing movement."""
+    toolhead.z_probing_move = mocker.Mock(return_value=0.5)
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+    move_spy = mocker.spy(toolhead, "move")
+
+    # effective samples = 5 (from config); passing max_samples=3 is impossible.
+    with pytest.raises(RuntimeError, match=r"max_samples \(3\) must be >= the effective samples \(5\)"):
+        _ = probe.touch.perform_probe(max_samples=3)
+
+    move_spy.assert_not_called()
+    toolhead.z_probing_move.assert_not_called()

--- a/tests/probes/test_touch_sampling_profile.py
+++ b/tests/probes/test_touch_sampling_profile.py
@@ -1,4 +1,4 @@
-"""Tests for model-specific sampling profile (samples / sample_range) with global fallback."""
+"""Tests for model-specific sampling profile (samples / sample_range) with loader inheritance."""
 
 from __future__ import annotations
 
@@ -23,26 +23,32 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def base_model(probe: Probe, config: Configuration) -> None:
-    """Register a minimal model with no sampling overrides (legacy-style)."""
+    """Register a model whose samples/sample_range match the mock global config (5 / 0.010).
+
+    This simulates a model that was loaded with inherited global values (as KlipperConfiguration
+    would do at startup for a legacy model section without explicit keys).
+    """
     config.save_touch_model(
         TouchModelConfiguration(
             name="default_model",
             speed=3,
             threshold=1000,
             z_offset=0,
-            # samples and sample_range intentionally absent → None
+            # Concrete values matching MockConfiguration defaults (samples=5, sample_range=0.010)
+            samples=5,
+            sample_range=0.010,
         )
     )
     probe.touch.load_model("default_model")
 
 
 # ---------------------------------------------------------------------------
-# Legacy fallback: model without samples/sample_range uses global config
+# Baseline: model carrying inherited global values behaves like global config
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_model_uses_global_samples(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
-    """A model with samples=None falls back to global samples (5 from MockConfiguration)."""
+def test_inherited_samples_used(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
+    """A model with samples=5 (inherited from global) requires 5 agreeing samples."""
     # Global config has samples=5; supply exactly 5 agreeing touches after 2 noisy ones
     # (window = 5 + 2 = 7; first 2 noisy, then 5 consistent → success)
     toolhead.z_probing_move = mocker.Mock(side_effect=[1.0, 2.0, 0.5, 0.5, 0.5, 0.5, 0.5])
@@ -52,8 +58,8 @@ def test_legacy_model_uses_global_samples(mocker: MockerFixture, toolhead: Toolh
     assert result == 0.5
 
 
-def test_legacy_model_uses_global_sample_range(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
-    """A model with sample_range=None falls back to global sample_range (0.010)."""
+def test_inherited_sample_range_used(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
+    """A model with sample_range=0.010 (inherited) rejects spreads wider than 0.010."""
     # 10 monotone values, each 0.003 apart: best-5-in-window-7 = range 0.012 > 0.010
     side = [round(0.500 + i * 0.003, 4) for i in range(10)]
     toolhead.z_probing_move = mocker.Mock(side_effect=side)
@@ -64,7 +70,7 @@ def test_legacy_model_uses_global_sample_range(mocker: MockerFixture, toolhead: 
 
 
 # ---------------------------------------------------------------------------
-# Model-specific overrides: stored values override global config
+# Model-specific overrides: stored values override inherited defaults
 # ---------------------------------------------------------------------------
 
 
@@ -79,6 +85,7 @@ def test_model_samples_override_used(
             threshold=1000,
             z_offset=0,
             samples=3,
+            sample_range=0.010,
         )
     )
     probe.touch.load_model("tight_samples")
@@ -101,6 +108,7 @@ def test_model_sample_range_override_used(
             speed=3,
             threshold=1000,
             z_offset=0,
+            samples=5,
             sample_range=0.005,
         )
     )
@@ -126,6 +134,7 @@ def test_model_sample_range_override_accepts_tight_spread(
             speed=3,
             threshold=1000,
             z_offset=0,
+            samples=5,
             sample_range=0.015,
         )
     )
@@ -157,6 +166,7 @@ def test_model_samples_window_anti_cherry_picking(
             threshold=1000,
             z_offset=0,
             samples=3,
+            sample_range=0.010,
         )
     )
     probe.touch.load_model("window_check")
@@ -184,6 +194,7 @@ def test_model_samples_window_succeeds_consecutive(
             threshold=1000,
             z_offset=0,
             samples=3,
+            sample_range=0.010,
         )
     )
     probe.touch.load_model("window_consecutive")

--- a/tests/probes/test_touch_sampling_profile.py
+++ b/tests/probes/test_touch_sampling_profile.py
@@ -1,0 +1,196 @@
+"""Tests for model-specific sampling profile (samples / sample_range) with global fallback."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cartographer.interfaces.configuration import Configuration, TouchModelConfiguration
+from cartographer.interfaces.printer import Position
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from cartographer.interfaces.printer import Toolhead
+    from cartographer.probe.probe import Probe
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — use project-level conftest fixtures (probe, toolhead, config)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def base_model(probe: Probe, config: Configuration) -> None:
+    """Register a minimal model with no sampling overrides (legacy-style)."""
+    config.save_touch_model(
+        TouchModelConfiguration(
+            name="default_model",
+            speed=3,
+            threshold=1000,
+            z_offset=0,
+            # samples and sample_range intentionally absent → None
+        )
+    )
+    probe.touch.load_model("default_model")
+
+
+# ---------------------------------------------------------------------------
+# Legacy fallback: model without samples/sample_range uses global config
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_model_uses_global_samples(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
+    """A model with samples=None falls back to global samples (5 from MockConfiguration)."""
+    # Global config has samples=5; supply exactly 5 agreeing touches after 2 noisy ones
+    # (window = 5 + 2 = 7; first 2 noisy, then 5 consistent → success)
+    toolhead.z_probing_move = mocker.Mock(side_effect=[1.0, 2.0, 0.5, 0.5, 0.5, 0.5, 0.5])
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    result = probe.touch.perform_probe()
+    assert result == 0.5
+
+
+def test_legacy_model_uses_global_sample_range(mocker: MockerFixture, toolhead: Toolhead, probe: Probe) -> None:
+    """A model with sample_range=None falls back to global sample_range (0.010)."""
+    # 10 monotone values, each 0.003 apart: best-5-in-window-7 = range 0.012 > 0.010
+    side = [round(0.500 + i * 0.003, 4) for i in range(10)]
+    toolhead.z_probing_move = mocker.Mock(side_effect=side)
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    with pytest.raises(RuntimeError, match="Unable to find"):
+        _ = probe.touch.perform_probe()
+
+
+# ---------------------------------------------------------------------------
+# Model-specific overrides: stored values override global config
+# ---------------------------------------------------------------------------
+
+
+def test_model_samples_override_used(
+    mocker: MockerFixture, toolhead: Toolhead, probe: Probe, config: Configuration
+) -> None:
+    """A model with samples=3 requires only 3 agreeing samples, even though global is 5."""
+    config.save_touch_model(
+        TouchModelConfiguration(
+            name="tight_samples",
+            speed=3,
+            threshold=1000,
+            z_offset=0,
+            samples=3,
+        )
+    )
+    probe.touch.load_model("tight_samples")
+
+    # 3 agreeing samples succeeds immediately (global would require 5)
+    toolhead.z_probing_move = mocker.Mock(side_effect=[0.5, 0.5, 0.5])
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    result = probe.touch.perform_probe()
+    assert result == 0.5
+
+
+def test_model_sample_range_override_used(
+    mocker: MockerFixture, toolhead: Toolhead, probe: Probe, config: Configuration
+) -> None:
+    """A model with sample_range=0.005 rejects a spread that global 0.010 would accept."""
+    config.save_touch_model(
+        TouchModelConfiguration(
+            name="tight_range",
+            speed=3,
+            threshold=1000,
+            z_offset=0,
+            sample_range=0.005,
+        )
+    )
+    probe.touch.load_model("tight_range")
+
+    # 10 monotone values 0.002 apart; best-5-in-window-7 spans 0.008
+    # 0.008 < global 0.010 but > model 0.005 → should fail
+    side = [round(0.500 + i * 0.002, 4) for i in range(10)]
+    toolhead.z_probing_move = mocker.Mock(side_effect=side)
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    with pytest.raises(RuntimeError, match="Unable to find"):
+        _ = probe.touch.perform_probe()
+
+
+def test_model_sample_range_override_accepts_tight_spread(
+    mocker: MockerFixture, toolhead: Toolhead, probe: Probe, config: Configuration
+) -> None:
+    """A model with sample_range=0.015 accepts a spread that global 0.010 would reject."""
+    config.save_touch_model(
+        TouchModelConfiguration(
+            name="loose_range",
+            speed=3,
+            threshold=1000,
+            z_offset=0,
+            sample_range=0.015,
+        )
+    )
+    probe.touch.load_model("loose_range")
+
+    # 5 samples spanning 0.012 — exceeds global 0.010, accepted by model's 0.015
+    toolhead.z_probing_move = mocker.Mock(side_effect=[0.500, 0.504, 0.508, 0.510, 0.512])
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    result = probe.touch.perform_probe()
+    assert abs(result - 0.508) < 0.001  # median of the 5 values
+
+
+# ---------------------------------------------------------------------------
+# Sliding window with model samples override — anti-cherry-picking preserved
+# ---------------------------------------------------------------------------
+
+
+def test_model_samples_window_anti_cherry_picking(
+    mocker: MockerFixture, toolhead: Toolhead, probe: Probe, config: Configuration
+) -> None:
+    """With model samples=3 and global max_noisy_samples=2, window=5.
+    Spread-out good samples beyond the window (every 3rd position) must still be rejected
+    because no window of 5 can contain all 3 agreeing samples without noisy ones."""
+    config.save_touch_model(
+        TouchModelConfiguration(
+            name="window_check",
+            speed=3,
+            threshold=1000,
+            z_offset=0,
+            samples=3,
+        )
+    )
+    probe.touch.load_model("window_check")
+
+    # Good values (0.5) appear every 3rd position; noises are monotone 2.0-2.5.
+    # Every 5-element window contains at most 2 goods and always has noise pairs
+    # that span >0.010 — no valid 3-sample subset exists in any window.
+    side = [0.5, 2.0, 2.1, 0.5, 2.2, 2.3, 0.5, 2.4, 2.5, 0.5]
+    toolhead.z_probing_move = mocker.Mock(side_effect=side)
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    with pytest.raises(RuntimeError, match="Unable to find"):
+        _ = probe.touch.perform_probe()
+
+
+def test_model_samples_window_succeeds_consecutive(
+    mocker: MockerFixture, toolhead: Toolhead, probe: Probe, config: Configuration
+) -> None:
+    """With model samples=3 and global max_noisy_samples=2, window=5.
+    Three consecutive good samples within the window succeed."""
+    config.save_touch_model(
+        TouchModelConfiguration(
+            name="window_consecutive",
+            speed=3,
+            threshold=1000,
+            z_offset=0,
+            samples=3,
+        )
+    )
+    probe.touch.load_model("window_consecutive")
+
+    # 2 noisy then 3 consistent
+    toolhead.z_probing_move = mocker.Mock(side_effect=[1.0, 2.0, 0.5, 0.5, 0.5])
+    toolhead.get_position = mocker.Mock(return_value=Position(0, 0, 1))
+
+    result = probe.touch.perform_probe()
+    assert result == 0.5


### PR DESCRIPTION
## Reason / issue reference

Touch calibration needs to support representative sampling settings for slower, high-temperature probing without allowing individual probe calls to weaken the calibrated acceptance criteria.

Closes #508

## Functional changes

`CARTOGRAPHER_TOUCH_CALIBRATE` now accepts `SAMPLES` and `SAMPLE_RANGE`, defaulting from `[cartographer touch]`, and persists both values in the resulting touch model.

`MAX_VERIFY_RANGE` defaults to twice the effective `SAMPLE_RANGE`. `CARTOGRAPHER_TOUCH_PROBE` accepts a per-call `MAX_SAMPLES` attempt budget.

Existing touch models without sampling fields inherit the current global configuration values when loaded; those values are written explicitly the next time the model is saved.

## Decisions and callouts

- Sampling criteria belong to the selected touch model and cannot be overridden by `CARTOGRAPHER_TOUCH_PROBE`.
- `MAX_SAMPLES` remains an operational attempt budget and is not persisted in the model.
- `SAMPLE_RANGE` is limited to 0.001–0.015 mm.
- Calibration rejects `SAMPLES` values above configured `max_samples` before movement.

## Install

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@feat/touch-calibration-sampling"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```