### PR TITLE
ci: use secure setup-uv cache defaults for releases

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -19,8 +19,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: true
       - name: Build
         run: uv build
         env:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: true
 
       - name: Generate docs
         run: |


### PR DESCRIPTION
## Reason / issue reference

PR #517 upgraded setup-uv to v10, whose default cache mode protects release-sensitive workflows. Explicit `enable-cache: true` bypassed that protection.

## Functional changes

Tag-based delivery and release-triggered documentation workflows no longer restore or save the uv cache. Normal integration CI caching remains unchanged.

## Decisions and callouts

Relies on setup-uv v10's `enable-cache: auto` default. Release workflows may spend slightly longer downloading dependencies.